### PR TITLE
[Feature] Déduplication SQLite — dedup.ts (#2)

### DIFF
--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -4,7 +4,7 @@ import path from "path";
 export interface ScrapedRecord {
   siret: string;
   nom: string;
-  telephone: string;
+  telephone: string | null;
   ville: string;
   scraped_at: string;
   source: string;
@@ -16,7 +16,7 @@ export interface ScrapedStats {
   notFound: number;
 }
 
-const DB_PATH = path.join("data", "scraper.db");
+const DB_PATH = path.join(__dirname, "..", "data", "scraper.db");
 
 let db: Database.Database | undefined;
 
@@ -26,6 +26,7 @@ function requireDb(): Database.Database {
 }
 
 export function initDb(): void {
+  if (db) return;
   db = new Database(DB_PATH);
   db.pragma("journal_mode = WAL");
   db.exec(`

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -1,4 +1,5 @@
 import Database from "better-sqlite3";
+import path from "path";
 
 export interface ScrapedRecord {
   siret: string;
@@ -15,6 +16,8 @@ export interface ScrapedStats {
   notFound: number;
 }
 
+const DB_PATH = path.join("data", "scraper.db");
+
 let db: Database.Database | undefined;
 
 function requireDb(): Database.Database {
@@ -23,26 +26,48 @@ function requireDb(): Database.Database {
 }
 
 export function initDb(): void {
-  // TODO: ouvrir data/scraper.db et créer la table scraped
+  db = new Database(DB_PATH);
+  db.pragma("journal_mode = WAL");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS scraped (
+      siret       TEXT PRIMARY KEY,
+      nom         TEXT,
+      telephone   TEXT,
+      ville       TEXT,
+      scraped_at  TEXT,
+      source      TEXT
+    )
+  `);
 }
 
 export function isKnown(siret: string): boolean {
-  void requireDb();
-  void siret;
-  return false;
+  const row = requireDb().prepare("SELECT 1 FROM scraped WHERE siret = ?").get(siret);
+  return row !== undefined;
 }
 
 export function insert(record: ScrapedRecord): void {
-  void requireDb();
-  void record;
+  requireDb()
+    .prepare(
+      "INSERT OR IGNORE INTO scraped (siret, nom, telephone, ville, scraped_at, source) VALUES (?, ?, ?, ?, ?, ?)"
+    )
+    .run(record.siret, record.nom, record.telephone, record.ville, record.scraped_at, record.source);
 }
 
 export function getStats(): ScrapedStats {
-  void requireDb();
-  return { total: 0, found: 0, notFound: 0 };
+  const row = requireDb()
+    .prepare(
+      `SELECT
+        COUNT(*) as total,
+        COUNT(CASE WHEN source != 'non_trouvé' THEN 1 END) as found,
+        COUNT(CASE WHEN source = 'non_trouvé' THEN 1 END) as notFound
+      FROM scraped`
+    )
+    .get() as { total: number; found: number; notFound: number };
+  return { total: row.total, found: row.found, notFound: row.notFound };
 }
 
 export function getAll(): ScrapedRecord[] {
-  void requireDb();
-  return [];
+  return requireDb()
+    .prepare("SELECT * FROM scraped ORDER BY scraped_at DESC")
+    .all() as ScrapedRecord[];
 }


### PR DESCRIPTION
## Contexte

Implémente le module de déduplication SQLite (`src/dedup.ts`) qui est la fondation du pipeline de scraping. Chaque autre module (pipeline, server, exporter) s'appuie dessus pour éviter de re-scraper un établissement déjà traité.

## Changements

- `initDb()` — ouvre `data/scraper.db` (via `__dirname`), active WAL, crée la table `scraped` si absente
- `isKnown(siret)` — retourne `true` si le SIRET est déjà en base
- `insert(record)` — `INSERT OR IGNORE` pour l'idempotence sur double appel
- `getStats()` — retourne `{ total, found, notFound }` via COUNT conditionnel SQL
- `getAll()` — retourne tous les enregistrements triés par date décroissante
- `telephone` typé `string | null` pour refléter la nullable SQLite

## Critères d'acceptance

- [x] `isKnown(siret)` retourne `true` si le SIRET est déjà en base
- [x] `insert(record)` insère un nouvel enregistrement
- [x] Double insert sur le même SIRET ne lève pas d'erreur (INSERT OR IGNORE)
- [x] `getStats()` retourne `{ total, found, notFound }`
- [x] La DB persiste entre deux exécutions du script
- [x] `npx tsc --noEmit` passe