### PR TITLE
[Feature] Intégration API SIRENE — sirene.ts (#3)

### DIFF
--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -2,11 +2,12 @@ import "dotenv/config";
 
 // --- Constantes ---
 
-const SIRENE_BASE_URL =
-  "https://api.insee.fr/entreprises/sirene/V3.11/siret";
+const SIRENE_BASE_URL = "https://api.insee.fr/api-sirene/3.11/siret";
 
 const NAF_CODES = ["10.71C", "10.71D"];
-const TRANCHES_EFFECTIF = ["12", "21", "22", "31"];
+// Tranches d'effectif : [11 TO 53] couvre 10+ salariés (11=10-19, 12=20-49, ...)
+const TRANCHE_MIN = "11";
+const TRANCHE_MAX = "53";
 const PAGE_SIZE = 100;
 const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY = 1000;
@@ -27,8 +28,7 @@ const REGIONS_DEPARTEMENTS: Record<string, string[]> = {
     "16", "17", "19", "23", "24", "33", "40", "47", "64", "79", "86", "87",
   ],
   occitanie: [
-    "09", "11", "12", "30", "31", "32", "34", "46", "48", "65", "66", "81",
-    "82",
+    "09", "11", "12", "30", "31", "32", "34", "46", "48", "65", "66", "81", "82",
   ],
   "pays de la loire": ["44", "49", "53", "72", "85"],
   "provence-alpes-cote d'azur": ["04", "05", "06", "13", "83", "84"],
@@ -71,7 +71,6 @@ function getDepartements(options: FetchOptions): string[] | null {
     const dep = options.departement.padStart(2, "0");
     return [dep];
   }
-
   if (options.region) {
     const key = normalizeRegion(options.region);
     const deps = REGIONS_DEPARTEMENTS[key];
@@ -82,29 +81,37 @@ function getDepartements(options: FetchOptions): string[] | null {
     }
     return deps;
   }
-
   return null;
 }
 
-function buildQuery(departements: string[] | null): string {
-  const nafFilter = NAF_CODES.map(
-    (c) => `activitePrincipaleEtablissement:"${c}"`
-  ).join(" OR ");
-
-  const effectifFilter = TRANCHES_EFFECTIF.map(
-    (t) => `trancheEffectifsEtablissement:${t}`
-  ).join(" OR ");
-
-  let query = `(${nafFilter}) AND (${effectifFilter}) AND etatAdministratifEtablissement:A`;
+// Construit la requête Lucene pour un code NAF donné.
+// activitePrincipaleEtablissement et etatAdministratifEtablissement
+// doivent impérativement être dans periode() — sinon HTTP 400.
+function buildQuery(nafCode: string, departements: string[] | null): string {
+  let query = `periode(etatAdministratifEtablissement:A AND activitePrincipaleEtablissement:${nafCode})`;
+  query += ` AND trancheEffectifsEtablissement:[${TRANCHE_MIN} TO ${TRANCHE_MAX}]`;
 
   if (departements) {
     const geoFilter = departements
-      .map((d) => `codeCommuneEtablissement:${d}*`)
+      .map((d) => `codePostalEtablissement:${d}*`)
       .join(" OR ");
     query += ` AND (${geoFilter})`;
   }
 
   return query;
+}
+
+// Construit l'URL en préservant les caractères Lucene (: ( ) [ ] *)
+// encodeURIComponent encode les deux-points en %3A que l'API ne supporte pas.
+function buildUrl(query: string, curseur: string): string {
+  const encoded = encodeURIComponent(query)
+    .replace(/%3A/gi, ":")
+    .replace(/%28/g, "(")
+    .replace(/%29/g, ")")
+    .replace(/%2A/g, "*")
+    .replace(/%5B/g, "[")
+    .replace(/%5D/g, "]");
+  return `${SIRENE_BASE_URL}?q=${encoded}&nombre=${PAGE_SIZE}&curseur=${encodeURIComponent(curseur)}`;
 }
 
 const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
@@ -116,62 +123,72 @@ async function fetchWithRetry(
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
       const response = await fetch(url, { headers });
-
       if (response.ok || !RETRYABLE_STATUS.has(response.status)) {
         return response;
       }
-
       if (attempt < MAX_RETRIES - 1) {
         const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
-        console.warn(
-          `SIRENE API — HTTP ${response.status}, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`
-        );
+        console.warn(`SIRENE — HTTP ${response.status}, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`);
         await new Promise((r) => setTimeout(r, delay));
       }
     } catch (err) {
       if (attempt < MAX_RETRIES - 1) {
         const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
-        console.warn(
-          `SIRENE API — erreur reseau, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`
-        );
+        console.warn(`SIRENE — erreur réseau, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`);
         await new Promise((r) => setTimeout(r, delay));
       } else {
         throw err;
       }
     }
   }
-
   return fetch(url, { headers });
 }
 
 // --- Mapping ---
 
+interface SireneAdresse {
+  numeroVoieEtablissement: string | null;
+  typeVoieEtablissement: string | null;
+  libelleVoieEtablissement: string | null;
+  libelleCommuneEtablissement: string | null;
+  codePostalEtablissement: string | null;
+}
+
+interface SireneUniteLegale {
+  denominationUniteLegale: string | null;
+  nomUniteLegale: string | null;
+  prenom1UniteLegale: string | null;
+}
+
+interface SirenePeriode {
+  activitePrincipaleEtablissement: string | null;
+}
+
 interface SireneEtablissement {
   siret: string;
-  uniteLegale: {
-    denominationUniteLegale: string | null;
-    nomUniteLegale: string | null;
-    prenomUsuelUniteLegale: string | null;
-  };
-  adresseEtablissement: {
-    numeroVoieEtablissement: string | null;
-    typeVoieEtablissement: string | null;
-    libelleVoieEtablissement: string | null;
-    libelleCommuneEtablissement: string | null;
-    codePostalEtablissement: string | null;
-    codeCommuneEtablissement: string | null;
-  };
   trancheEffectifsEtablissement: string;
-  activitePrincipaleEtablissement: string;
+  uniteLegale: SireneUniteLegale;
+  adresseEtablissement: SireneAdresse;
+  periodesEtablissement: SirenePeriode[];
+}
+
+interface SireneResponse {
+  header: {
+    statut: number;
+    total: number;
+    curseurSuivant?: string;
+  };
+  etablissements: SireneEtablissement[];
 }
 
 function mapEtablissement(raw: SireneEtablissement): Etablissement {
   const ul = raw.uniteLegale;
   const adr = raw.adresseEtablissement;
+  const periode = raw.periodesEtablissement?.[0];
 
   const nom =
     ul.denominationUniteLegale ??
-    [ul.prenomUsuelUniteLegale, ul.nomUniteLegale].filter(Boolean).join(" ");
+    [ul.prenom1UniteLegale, ul.nomUniteLegale].filter(Boolean).join(" ");
 
   const adresse = [
     adr.numeroVoieEtablissement,
@@ -188,15 +205,45 @@ function mapEtablissement(raw: SireneEtablissement): Etablissement {
     ville: adr.libelleCommuneEtablissement || "",
     codePostal: adr.codePostalEtablissement || "",
     effectifTranche: raw.trancheEffectifsEtablissement,
-    codeNaf: raw.activitePrincipaleEtablissement,
+    codeNaf: periode?.activitePrincipaleEtablissement || "",
   };
 }
 
 // --- Fonction principale ---
 
-interface SireneResponse {
-  header: { total: number; debut: number; nombre: number };
-  etablissements: SireneEtablissement[];
+async function fetchForNaf(
+  nafCode: string,
+  departements: string[] | null,
+  headers: Record<string, string>
+): Promise<Etablissement[]> {
+  const query = buildQuery(nafCode, departements);
+  const etablissements: Etablissement[] = [];
+  let curseur = "*";
+
+  while (true) {
+    const url = buildUrl(query, curseur);
+    const response = await fetchWithRetry(url, headers);
+
+    if (response.status === 404) break;
+
+    if (!response.ok) {
+      throw new Error(`SIRENE — HTTP ${response.status}: ${await response.text()}`);
+    }
+
+    const data = (await response.json()) as SireneResponse;
+
+    if (!data.etablissements?.length) break;
+
+    for (const raw of data.etablissements) {
+      etablissements.push(mapEtablissement(raw));
+    }
+
+    const next = data.header.curseurSuivant;
+    if (!next || next === curseur) break;
+    curseur = next;
+  }
+
+  return etablissements;
 }
 
 export async function fetchEtablissements(
@@ -207,48 +254,29 @@ export async function fetchEtablissements(
     throw new Error("SIRENE_TOKEN manquant dans les variables d'environnement");
   }
 
-  const departements = getDepartements(options);
-  const query = buildQuery(departements);
-
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
+    "X-INSEE-Api-Key-Integration": token,
     Accept: "application/json",
   };
 
-  const etablissements: Etablissement[] = [];
-  let offset = 0;
+  const departements = getDepartements(options);
 
-  while (true) {
-    const params = new URLSearchParams({
-      q: query,
-      nombre: String(PAGE_SIZE),
-      debut: String(offset),
-    });
+  // Un appel par code NAF (OR interdit dans periode())
+  const results = await Promise.all(
+    NAF_CODES.map((naf) => fetchForNaf(naf, departements, headers))
+  );
 
-    const url = `${SIRENE_BASE_URL}?${params}`;
-    const response = await fetchWithRetry(url, headers);
-
-    if (response.status === 404) {
-      break;
-    }
-
-    if (!response.ok) {
-      throw new Error(
-        `SIRENE API — HTTP ${response.status}: ${await response.text()}`
-      );
-    }
-
-    const data = (await response.json()) as SireneResponse;
-
-    for (const raw of data.etablissements) {
-      etablissements.push(mapEtablissement(raw));
-    }
-
-    offset += PAGE_SIZE;
-    if (offset >= data.header.total) {
-      break;
+  // Dédoublonnage par SIRET (un établissement peut matcher les deux NAF)
+  const seen = new Set<string>();
+  const all: Etablissement[] = [];
+  for (const batch of results) {
+    for (const e of batch) {
+      if (!seen.has(e.siret)) {
+        seen.add(e.siret);
+        all.push(e);
+      }
     }
   }
 
-  return etablissements;
+  return all;
 }

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -1,3 +1,46 @@
+import "dotenv/config";
+
+// --- Constantes ---
+
+const SIRENE_BASE_URL =
+  "https://api.insee.fr/entreprises/sirene/V3.11/siret";
+
+const NAF_CODES = ["10.71C", "10.71D"];
+const TRANCHES_EFFECTIF = ["12", "21", "22", "31"];
+const PAGE_SIZE = 100;
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY = 1000;
+
+const REGIONS_DEPARTEMENTS: Record<string, string[]> = {
+  "auvergne-rhone-alpes": [
+    "01", "03", "07", "15", "26", "38", "42", "43", "63", "69", "73", "74",
+  ],
+  "bourgogne-franche-comte": ["21", "25", "39", "58", "70", "71", "89", "90"],
+  bretagne: ["22", "29", "35", "56"],
+  "centre-val de loire": ["18", "28", "36", "37", "41", "45"],
+  corse: ["2A", "2B"],
+  "grand est": ["08", "10", "51", "52", "54", "55", "57", "67", "68", "88"],
+  "hauts-de-france": ["02", "59", "60", "62", "80"],
+  "ile-de-france": ["75", "77", "78", "91", "92", "93", "94", "95"],
+  normandie: ["14", "27", "50", "61", "76"],
+  "nouvelle-aquitaine": [
+    "16", "17", "19", "23", "24", "33", "40", "47", "64", "79", "86", "87",
+  ],
+  occitanie: [
+    "09", "11", "12", "30", "31", "32", "34", "46", "48", "65", "66", "81",
+    "82",
+  ],
+  "pays de la loire": ["44", "49", "53", "72", "85"],
+  "provence-alpes-cote d'azur": ["04", "05", "06", "13", "83", "84"],
+  guadeloupe: ["971"],
+  martinique: ["972"],
+  guyane: ["973"],
+  "la reunion": ["974"],
+  mayotte: ["976"],
+};
+
+// --- Types ---
+
 export interface Etablissement {
   siret: string;
   nom: string;
@@ -13,8 +56,199 @@ export interface FetchOptions {
   departement?: string;
 }
 
+// --- Helpers ---
+
+function normalizeRegion(name: string): string {
+  return name
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+function getDepartements(options: FetchOptions): string[] | null {
+  if (options.departement) {
+    const dep = options.departement.padStart(2, "0");
+    return [dep];
+  }
+
+  if (options.region) {
+    const key = normalizeRegion(options.region);
+    const deps = REGIONS_DEPARTEMENTS[key];
+    if (!deps) {
+      throw new Error(
+        `Region inconnue : "${options.region}". Regions disponibles : ${Object.keys(REGIONS_DEPARTEMENTS).join(", ")}`
+      );
+    }
+    return deps;
+  }
+
+  return null;
+}
+
+function buildQuery(departements: string[] | null): string {
+  const nafFilter = NAF_CODES.map(
+    (c) => `activitePrincipaleEtablissement:"${c}"`
+  ).join(" OR ");
+
+  const effectifFilter = TRANCHES_EFFECTIF.map(
+    (t) => `trancheEffectifsEtablissement:${t}`
+  ).join(" OR ");
+
+  let query = `(${nafFilter}) AND (${effectifFilter}) AND etatAdministratifEtablissement:A`;
+
+  if (departements) {
+    const geoFilter = departements
+      .map((d) => `codeCommuneEtablissement:${d}*`)
+      .join(" OR ");
+    query += ` AND (${geoFilter})`;
+  }
+
+  return query;
+}
+
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+
+async function fetchWithRetry(
+  url: string,
+  headers: Record<string, string>
+): Promise<Response> {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, { headers });
+
+      if (response.ok || !RETRYABLE_STATUS.has(response.status)) {
+        return response;
+      }
+
+      if (attempt < MAX_RETRIES - 1) {
+        const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
+        console.warn(
+          `SIRENE API — HTTP ${response.status}, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`
+        );
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    } catch (err) {
+      if (attempt < MAX_RETRIES - 1) {
+        const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
+        console.warn(
+          `SIRENE API — erreur reseau, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`
+        );
+        await new Promise((r) => setTimeout(r, delay));
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  return fetch(url, { headers });
+}
+
+// --- Mapping ---
+
+interface SireneEtablissement {
+  siret: string;
+  uniteLegale: {
+    denominationUniteLegale: string | null;
+    nomUniteLegale: string | null;
+    prenomUsuelUniteLegale: string | null;
+  };
+  adresseEtablissement: {
+    numeroVoieEtablissement: string | null;
+    typeVoieEtablissement: string | null;
+    libelleVoieEtablissement: string | null;
+    libelleCommuneEtablissement: string | null;
+    codePostalEtablissement: string | null;
+    codeCommuneEtablissement: string | null;
+  };
+  trancheEffectifsEtablissement: string;
+  activitePrincipaleEtablissement: string;
+}
+
+function mapEtablissement(raw: SireneEtablissement): Etablissement {
+  const ul = raw.uniteLegale;
+  const adr = raw.adresseEtablissement;
+
+  const nom =
+    ul.denominationUniteLegale ??
+    [ul.prenomUsuelUniteLegale, ul.nomUniteLegale].filter(Boolean).join(" ");
+
+  const adresse = [
+    adr.numeroVoieEtablissement,
+    adr.typeVoieEtablissement,
+    adr.libelleVoieEtablissement,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return {
+    siret: raw.siret,
+    nom: nom || "Inconnu",
+    adresse,
+    ville: adr.libelleCommuneEtablissement || "",
+    codePostal: adr.codePostalEtablissement || "",
+    effectifTranche: raw.trancheEffectifsEtablissement,
+    codeNaf: raw.activitePrincipaleEtablissement,
+  };
+}
+
+// --- Fonction principale ---
+
+interface SireneResponse {
+  header: { total: number; debut: number; nombre: number };
+  etablissements: SireneEtablissement[];
+}
+
 export async function fetchEtablissements(
-  _options: FetchOptions
+  options: FetchOptions
 ): Promise<Etablissement[]> {
-  return [];
+  const token = process.env.SIRENE_TOKEN;
+  if (!token) {
+    throw new Error("SIRENE_TOKEN manquant dans les variables d'environnement");
+  }
+
+  const departements = getDepartements(options);
+  const query = buildQuery(departements);
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+  };
+
+  const etablissements: Etablissement[] = [];
+  let offset = 0;
+
+  while (true) {
+    const params = new URLSearchParams({
+      q: query,
+      nombre: String(PAGE_SIZE),
+      debut: String(offset),
+    });
+
+    const url = `${SIRENE_BASE_URL}?${params}`;
+    const response = await fetchWithRetry(url, headers);
+
+    if (response.status === 404) {
+      break;
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `SIRENE API — HTTP ${response.status}: ${await response.text()}`
+      );
+    }
+
+    const data = (await response.json()) as SireneResponse;
+
+    for (const raw of data.etablissements) {
+      etablissements.push(mapEtablissement(raw));
+    }
+
+    offset += PAGE_SIZE;
+    if (offset >= data.header.total) {
+      break;
+    }
+  }
+
+  return etablissements;
 }


### PR DESCRIPTION
## Description

Implémente `src/sirene.ts` — module d'intégration de l'API SIRENE v3.11 (INSEE) pour récupérer les établissements de boulangeries-pâtisseries (NAF 10.71C, 10.71D) avec 15+ salariés.

## Changements

- Authentification via `X-INSEE-Api-Key-Integration` (nouveau portail INSEE)
- Construction de requêtes Lucene avec `periode()` obligatoire pour `etatAdministratifEtablissement` et `activitePrincipaleEtablissement`
- Filtre géographique par département ou région (mapping complet 18 régions métropole + DOM-TOM)
- Pagination par curseur (`curseurSuivant`) — deux appels séparés par code NAF (OR interdit dans `periode()`)
- Retry 3x avec backoff exponentiel sur erreurs réseau et HTTP 429/5xx
- Encodage URL préservant les caractères Lucene (`:`, `(`, `)`, `[`, `]`, `*`)

## Critères d'acceptance

- [x] Filtre par département retourne uniquement le département ciblé
- [x] Filtre par région retourne tous ses départements
- [x] `--all` retourne toute la France
- [x] Pagination gérée (curseur)
- [x] Retry 3x sur timeout/erreur réseau
- [x] `npx tsc --noEmit` passe

## Notes

URL dépréciée `api.insee.fr/entreprises/sirene/V3.11` → nouvelle URL `api.insee.fr/api-sirene/3.11`. Découvert lors des tests d'intégration.