### PR TITLE
[Feature] Pipeline d'orchestration — pipeline.ts (#6)

### DIFF
--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -105,12 +105,13 @@ export function getAll(): ScrapedRecord[] {
 }
 
 export function getPaginated(page: number, limit: number): PaginatedResult<ScrapedRecord> {
-  const db = requireDb();
-  const { count } = db.prepare("SELECT COUNT(*) as count FROM scraped").get() as { count: number };
+  if (limit < 1) throw new Error("limit doit être >= 1");
+  const conn = requireDb();
+  const { count } = conn.prepare("SELECT COUNT(*) as count FROM scraped").get() as { count: number };
   const totalPages = Math.max(1, Math.ceil(count / limit));
   const safePage = Math.max(1, Math.min(page, totalPages));
   const offset = (safePage - 1) * limit;
-  const data = db
+  const data = conn
     .prepare(`SELECT ${SELECT_FIELDS} FROM scraped ORDER BY scraped_at DESC LIMIT ? OFFSET ?`)
     .all(limit, offset) as ScrapedRecord[];
   return { data, total: count, page: safePage, totalPages };

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -4,10 +4,13 @@ import path from "path";
 export interface ScrapedRecord {
   siret: string;
   nom: string;
-  telephone: string | null;
+  adresse: string;
   ville: string;
-  scraped_at: string;
+  codePostal: string;
+  telephone: string | null;
+  effectifTranche: string;
   source: string;
+  scraped_at: string;
 }
 
 export interface ScrapedStats {
@@ -38,12 +41,15 @@ export function initDb(): void {
   db.pragma("journal_mode = WAL");
   db.exec(`
     CREATE TABLE IF NOT EXISTS scraped (
-      siret       TEXT PRIMARY KEY,
-      nom         TEXT,
-      telephone   TEXT,
-      ville       TEXT,
-      scraped_at  TEXT,
-      source      TEXT
+      siret             TEXT PRIMARY KEY,
+      nom               TEXT,
+      adresse           TEXT,
+      ville             TEXT,
+      code_postal       TEXT,
+      telephone         TEXT,
+      effectif_tranche  TEXT,
+      source            TEXT,
+      scraped_at        TEXT
     )
   `);
 }
@@ -56,9 +62,21 @@ export function isKnown(siret: string): boolean {
 export function insert(record: ScrapedRecord): void {
   requireDb()
     .prepare(
-      "INSERT OR IGNORE INTO scraped (siret, nom, telephone, ville, scraped_at, source) VALUES (?, ?, ?, ?, ?, ?)"
+      `INSERT OR IGNORE INTO scraped
+        (siret, nom, adresse, ville, code_postal, telephone, effectif_tranche, source, scraped_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
-    .run(record.siret, record.nom, record.telephone, record.ville, record.scraped_at, record.source);
+    .run(
+      record.siret,
+      record.nom,
+      record.adresse,
+      record.ville,
+      record.codePostal,
+      record.telephone,
+      record.effectifTranche,
+      record.source,
+      record.scraped_at,
+    );
 }
 
 export function getStats(): ScrapedStats {
@@ -74,9 +92,15 @@ export function getStats(): ScrapedStats {
   return { total: row.total, found: row.found, notFound: row.notFound };
 }
 
+const SELECT_FIELDS = `
+  siret, nom, adresse, ville,
+  code_postal as codePostal, telephone,
+  effectif_tranche as effectifTranche, source, scraped_at
+`;
+
 export function getAll(): ScrapedRecord[] {
   return requireDb()
-    .prepare("SELECT * FROM scraped ORDER BY scraped_at DESC")
+    .prepare(`SELECT ${SELECT_FIELDS} FROM scraped ORDER BY scraped_at DESC`)
     .all() as ScrapedRecord[];
 }
 
@@ -87,7 +111,7 @@ export function getPaginated(page: number, limit: number): PaginatedResult<Scrap
   const safePage = Math.max(1, Math.min(page, totalPages));
   const offset = (safePage - 1) * limit;
   const data = db
-    .prepare("SELECT * FROM scraped ORDER BY scraped_at DESC LIMIT ? OFFSET ?")
+    .prepare(`SELECT ${SELECT_FIELDS} FROM scraped ORDER BY scraped_at DESC LIMIT ? OFFSET ?`)
     .all(limit, offset) as ScrapedRecord[];
   return { data, total: count, page: safePage, totalPages };
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -10,14 +10,10 @@ export interface PipelineResult {
   prospects: ScrapedRecord[];
 }
 
-export type ProgressCallback = (
-  current: number,
-  total: number,
-  nom: string
-) => void;
+export type ProgressCallback = (current: number, nom: string) => void;
 
 export async function runPipeline(
-  etablissements: Etablissement[],
+  source: Iterable<Etablissement> | AsyncIterable<Etablissement>,
   onProgress?: ProgressCallback,
   limit?: number
 ): Promise<PipelineResult> {
@@ -27,17 +23,17 @@ export async function runPipeline(
   let alreadyKnown = 0;
   let notFoundCount = 0;
   const prospects: ScrapedRecord[] = [];
-
   let i = 0;
-  for (const etab of etablissements) {
-    onProgress?.(++i, etablissements.length, etab.nom);
 
+  for await (const etab of source) {
     if (isKnown(etab.siret)) {
       alreadyKnown++;
       continue;
     }
 
     if (limit !== undefined && newCount + notFoundCount >= limit) break;
+
+    onProgress?.(++i, etab.nom);
 
     let phone = await findPhoneGoogle(etab.nom, etab.ville);
     let source: string;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -30,13 +30,14 @@ export async function runPipeline(
 
   let i = 0;
   for (const etab of etablissements) {
-    if (limit !== undefined && newCount + notFoundCount >= limit) break;
     onProgress?.(++i, etablissements.length, etab.nom);
 
     if (isKnown(etab.siret)) {
       alreadyKnown++;
       continue;
     }
+
+    if (limit !== undefined && newCount + notFoundCount >= limit) break;
 
     let phone = await findPhoneGoogle(etab.nom, etab.ville);
     let source: string;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -27,41 +27,48 @@ export async function runPipeline(
   let notFoundCount = 0;
   const prospects: ScrapedRecord[] = [];
 
-  for (let i = 0; i < etablissements.length; i++) {
-    const e = etablissements[i];
-    onProgress?.(i + 1, etablissements.length, e.nom);
+  let i = 0;
+  for (const etab of etablissements) {
+    onProgress?.(++i, etablissements.length, etab.nom);
 
-    if (isKnown(e.siret)) {
+    if (isKnown(etab.siret)) {
       alreadyKnown++;
       continue;
     }
 
-    let phone = await findPhoneGoogle(e.nom, e.ville);
-    let source = "google";
+    let phone = await findPhoneGoogle(etab.nom, etab.ville);
+    let source: string;
 
-    if (phone === null) {
-      phone = await findPhonePJ(e.nom, e.ville);
-      source = "pagesjaunes";
+    if (phone !== null) {
+      source = "google";
+    } else {
+      phone = await findPhonePJ(etab.nom, etab.ville);
+      source = phone !== null ? "pagesjaunes" : "non_trouvé";
     }
 
     if (phone === null) {
-      source = "non_trouvé";
       notFoundCount++;
     } else {
       newCount++;
     }
 
     const record: ScrapedRecord = {
-      siret: e.siret,
-      nom: e.nom,
+      siret: etab.siret,
+      nom: etab.nom,
+      adresse: etab.adresse,
+      ville: etab.ville,
+      codePostal: etab.codePostal,
       telephone: phone,
-      ville: e.ville,
-      scraped_at: new Date().toISOString(),
+      effectifTranche: etab.effectifTranche,
       source,
+      scraped_at: new Date().toISOString(),
     };
 
     insert(record);
-    prospects.push(record);
+
+    if (source !== "non_trouvé") {
+      prospects.push(record);
+    }
   }
 
   return { newCount, alreadyKnown, notFoundCount, prospects };

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,5 +1,7 @@
 import { Etablissement } from "./sirene";
-import { ScrapedRecord } from "./dedup";
+import { initDb, isKnown, insert, ScrapedRecord } from "./dedup";
+import { findPhoneGoogle } from "./googleMaps";
+import { findPhonePJ } from "./pagesJaunes";
 
 export interface PipelineResult {
   newCount: number;
@@ -15,8 +17,52 @@ export type ProgressCallback = (
 ) => void;
 
 export async function runPipeline(
-  _etablissements: Etablissement[],
-  _onProgress?: ProgressCallback
+  etablissements: Etablissement[],
+  onProgress?: ProgressCallback
 ): Promise<PipelineResult> {
-  return { newCount: 0, alreadyKnown: 0, notFoundCount: 0, prospects: [] };
+  initDb();
+
+  let newCount = 0;
+  let alreadyKnown = 0;
+  let notFoundCount = 0;
+  const prospects: ScrapedRecord[] = [];
+
+  for (let i = 0; i < etablissements.length; i++) {
+    const e = etablissements[i];
+    onProgress?.(i + 1, etablissements.length, e.nom);
+
+    if (isKnown(e.siret)) {
+      alreadyKnown++;
+      continue;
+    }
+
+    let phone = await findPhoneGoogle(e.nom, e.ville);
+    let source = "google";
+
+    if (phone === null) {
+      phone = await findPhonePJ(e.nom, e.ville);
+      source = "pagesjaunes";
+    }
+
+    if (phone === null) {
+      source = "non_trouvé";
+      notFoundCount++;
+    } else {
+      newCount++;
+    }
+
+    const record: ScrapedRecord = {
+      siret: e.siret,
+      nom: e.nom,
+      telephone: phone,
+      ville: e.ville,
+      scraped_at: new Date().toISOString(),
+      source,
+    };
+
+    insert(record);
+    prospects.push(record);
+  }
+
+  return { newCount, alreadyKnown, notFoundCount, prospects };
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -18,7 +18,8 @@ export type ProgressCallback = (
 
 export async function runPipeline(
   etablissements: Etablissement[],
-  onProgress?: ProgressCallback
+  onProgress?: ProgressCallback,
+  limit?: number
 ): Promise<PipelineResult> {
   initDb();
 
@@ -29,6 +30,7 @@ export async function runPipeline(
 
   let i = 0;
   for (const etab of etablissements) {
+    if (limit !== undefined && newCount + notFoundCount >= limit) break;
     onProgress?.(++i, etablissements.length, etab.nom);
 
     if (isKnown(etab.siret)) {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -597,7 +597,7 @@
 
       <div class="field">
         <label>Limite</label>
-        <input type="text" id="limit" placeholder="ex : 50  (vide = tout scraper)">
+        <input type="number" id="limit" placeholder="ex : 50  (vide = tout scraper)" min="1">
       </div>
 
       <button class="btn-run" id="btnScrape" onclick="startScrape()">
@@ -756,12 +756,6 @@
 
     function changePage(d) { fetchResults(currentPage + d); }
 
-    function esc(s) {
-      const d = document.createElement("div");
-      d.textContent = s != null ? s : "";
-      return d.innerHTML;
-    }
-
     /* ── Scrape ── */
     async function startScrape() {
       const btn = document.getElementById("btnScrape");
@@ -826,10 +820,20 @@
           lastDupes += state.result.alreadyKnown;
           counter(document.getElementById("statDuplicates"), lastDupes);
 
-          document.getElementById("resultRows").innerHTML =
-            '<div class="result-row"><span class="result-key">Nouveaux</span><span class="result-val new">+' + state.result.newCount + '</span></div>' +
-            '<div class="result-row"><span class="result-key">Déjà connus</span><span class="result-val dupe">' + state.result.alreadyKnown + '</span></div>' +
-            '<div class="result-row"><span class="result-key">Non trouvés</span><span class="result-val nf">' + state.result.notFoundCount + '</span></div>';
+          const rows = [
+            { label: "Nouveaux",     val: "+" + state.result.newCount,      cls: "new"  },
+            { label: "Déjà connus",  val: state.result.alreadyKnown,        cls: "dupe" },
+            { label: "Non trouvés",  val: state.result.notFoundCount,        cls: "nf"   },
+          ];
+          const resultRows = document.getElementById("resultRows");
+          resultRows.innerHTML = "";
+          rows.forEach(function(r) {
+            const div  = document.createElement("div");  div.className = "result-row";
+            const key  = document.createElement("span"); key.className = "result-key";  key.textContent = r.label;
+            const val  = document.createElement("span"); val.className = "result-val " + r.cls; val.textContent = r.val;
+            div.append(key, val);
+            resultRows.appendChild(div);
+          });
 
           document.getElementById("resultBlock").classList.add("visible");
         }

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -595,9 +595,9 @@
         <span>Toute la France</span>
       </label>
 
-      <div class="field" style="margin-top:0.9rem">
-        <label>Limite (optionnel)</label>
-        <input type="number" id="limit" placeholder="ex : 50  (vide = tout scraper)" min="1">
+      <div class="field">
+        <label>Limite</label>
+        <input type="text" id="limit" placeholder="ex : 50  (vide = tout scraper)">
       </div>
 
       <button class="btn-run" id="btnScrape" onclick="startScrape()">

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -595,6 +595,11 @@
         <span>Toute la France</span>
       </label>
 
+      <div class="field" style="margin-top:0.9rem">
+        <label>Limite (optionnel)</label>
+        <input type="number" id="limit" placeholder="ex : 50  (vide = tout scraper)" min="1">
+      </div>
+
       <button class="btn-run" id="btnScrape" onclick="startScrape()">
         → Lancer le scrape
       </button>
@@ -772,6 +777,8 @@
         if (region) body.region = region;
         if (dep)    body.departement = dep;
       }
+      const limitVal = parseInt(document.getElementById("limit").value);
+      if (!isNaN(limitVal) && limitVal > 0) body.limit = limitVal;
 
       const res = await fetch("/api/scrape", {
         method: "POST",

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,12 +46,15 @@ app.post("/api/scrape", (req, res) => {
     return;
   }
 
-  const { region, departement, all, limit } = req.body as {
+  const { region, departement, all, limit: rawLimit } = req.body as {
     region?: string;
     departement?: string;
     all?: boolean;
     limit?: number;
   };
+  const limit = typeof rawLimit === "number" && Number.isFinite(rawLimit)
+    ? Math.max(1, Math.min(rawLimit, 10000))
+    : undefined;
 
   scrapeState = { status: "running", progress: 0, total: 0, current: "" };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,7 +59,7 @@ app.post("/api/scrape", (req, res) => {
   scrapeState = { status: "running", progress: 0, total: 0, current: "" };
 
   (async () => {
-    const options = all ? {} : { region, departement };
+    const options = all ? { limit } : { region, departement, limit };
     const etablissements = await fetchEtablissements(options);
     scrapeState.total = etablissements.length;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import path from "path";
 import express from "express";
 import { initDb, getStats, getAll, getPaginated } from "./dedup";
-import { fetchEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
+import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
 import { runPipeline } from "./pipeline";
 
 const app = express();
@@ -60,12 +60,19 @@ app.post("/api/scrape", (req, res) => {
 
   (async () => {
     const options = all ? {} : { region, departement };
-    const etablissements = await fetchEtablissements(options);
-    scrapeState.total = limit ?? etablissements.length;
 
-    const result = await runPipeline(etablissements, (current, total, nom) => {
+    let source: Iterable<import("./sirene").Etablissement> | AsyncIterable<import("./sirene").Etablissement>;
+    if (limit !== undefined) {
+      scrapeState.total = limit;
+      source = streamEtablissements(options);
+    } else {
+      const etablissements = await fetchEtablissements(options);
+      scrapeState.total = etablissements.length;
+      source = etablissements;
+    }
+
+    const result = await runPipeline(source, (current, nom) => {
       scrapeState.progress = current;
-      scrapeState.total = total;
       scrapeState.current = nom;
     }, limit);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,9 +59,9 @@ app.post("/api/scrape", (req, res) => {
   scrapeState = { status: "running", progress: 0, total: 0, current: "" };
 
   (async () => {
-    const options = all ? { limit } : { region, departement, limit };
+    const options = all ? {} : { region, departement };
     const etablissements = await fetchEtablissements(options);
-    scrapeState.total = etablissements.length;
+    scrapeState.total = limit ?? etablissements.length;
 
     const result = await runPipeline(etablissements, (current, total, nom) => {
       scrapeState.progress = current;

--- a/src/server.ts
+++ b/src/server.ts
@@ -86,7 +86,7 @@ app.get("/api/status", (_req, res) => {
 app.get("/api/export", (_req, res) => {
   const records = getAll();
 
-  const header = "siret,nom,telephone,ville,scraped_at,source";
+  const header = "siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,source,scraped_at";
   const rows = records.map((r) => {
     const escape = (v: string | null) => {
       if (!v) return "";
@@ -95,7 +95,7 @@ app.get("/api/export", (_req, res) => {
       }
       return v;
     };
-    return [r.siret, r.nom, r.telephone, r.ville, r.scraped_at, r.source]
+    return [r.siret, r.nom, r.adresse, r.ville, r.codePostal, r.telephone, r.effectifTranche, r.source, r.scraped_at]
       .map(escape)
       .join(",");
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,10 +46,11 @@ app.post("/api/scrape", (req, res) => {
     return;
   }
 
-  const { region, departement, all } = req.body as {
+  const { region, departement, all, limit } = req.body as {
     region?: string;
     departement?: string;
     all?: boolean;
+    limit?: number;
   };
 
   scrapeState = { status: "running", progress: 0, total: 0, current: "" };
@@ -63,7 +64,7 @@ app.post("/api/scrape", (req, res) => {
       scrapeState.progress = current;
       scrapeState.total = total;
       scrapeState.current = nom;
-    });
+    }, limit);
 
     scrapeState.status = "done";
     scrapeState.result = {

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -54,7 +54,6 @@ export interface Etablissement {
 export interface FetchOptions {
   region?: string;
   departement?: string;
-  limit?: number;
 }
 
 // --- Helpers ---
@@ -215,8 +214,7 @@ function mapEtablissement(raw: SireneEtablissement): Etablissement {
 async function fetchForNaf(
   nafCode: string,
   departements: string[] | null,
-  headers: Record<string, string>,
-  limit?: number
+  headers: Record<string, string>
 ): Promise<Etablissement[]> {
   const query = buildQuery(nafCode, departements);
   const etablissements: Etablissement[] = [];
@@ -238,7 +236,6 @@ async function fetchForNaf(
 
     for (const raw of data.etablissements) {
       etablissements.push(mapEtablissement(raw));
-      if (limit !== undefined && etablissements.length >= limit) return etablissements;
     }
 
     const next = data.header.curseurSuivant;
@@ -264,11 +261,9 @@ export async function fetchEtablissements(
 
   const departements = getDepartements(options);
 
-  const { limit } = options;
-
   // Un appel par code NAF (OR interdit dans periode())
   const results = await Promise.all(
-    NAF_CODES.map((naf) => fetchForNaf(naf, departements, headers, limit))
+    NAF_CODES.map((naf) => fetchForNaf(naf, departements, headers))
   );
 
   // Dédoublonnage par SIRET (un établissement peut matcher les deux NAF)
@@ -279,7 +274,6 @@ export async function fetchEtablissements(
       if (!seen.has(e.siret)) {
         seen.add(e.siret);
         all.push(e);
-        if (limit !== undefined && all.length >= limit) return all;
       }
     }
   }

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -211,13 +211,12 @@ function mapEtablissement(raw: SireneEtablissement): Etablissement {
 
 // --- Fonction principale ---
 
-async function fetchForNaf(
+async function* streamForNaf(
   nafCode: string,
   departements: string[] | null,
   headers: Record<string, string>
-): Promise<Etablissement[]> {
+): AsyncGenerator<Etablissement> {
   const query = buildQuery(nafCode, departements);
-  const etablissements: Etablissement[] = [];
   let curseur = "*";
 
   while (true) {
@@ -235,20 +234,18 @@ async function fetchForNaf(
     if (!data.etablissements?.length) break;
 
     for (const raw of data.etablissements) {
-      etablissements.push(mapEtablissement(raw));
+      yield mapEtablissement(raw);
     }
 
     const next = data.header.curseurSuivant;
     if (!next || next === curseur) break;
     curseur = next;
   }
-
-  return etablissements;
 }
 
-export async function fetchEtablissements(
+export async function* streamEtablissements(
   options: FetchOptions
-): Promise<Etablissement[]> {
+): AsyncGenerator<Etablissement> {
   const token = process.env.SIRENE_TOKEN;
   if (!token) {
     throw new Error("SIRENE_TOKEN manquant dans les variables d'environnement");
@@ -260,23 +257,24 @@ export async function fetchEtablissements(
   };
 
   const departements = getDepartements(options);
-
-  // Un appel par code NAF (OR interdit dans periode())
-  const results = await Promise.all(
-    NAF_CODES.map((naf) => fetchForNaf(naf, departements, headers))
-  );
-
-  // Dédoublonnage par SIRET (un établissement peut matcher les deux NAF)
   const seen = new Set<string>();
-  const all: Etablissement[] = [];
-  for (const batch of results) {
-    for (const e of batch) {
-      if (!seen.has(e.siret)) {
-        seen.add(e.siret);
-        all.push(e);
+
+  for (const nafCode of NAF_CODES) {
+    for await (const etab of streamForNaf(nafCode, departements, headers)) {
+      if (!seen.has(etab.siret)) {
+        seen.add(etab.siret);
+        yield etab;
       }
     }
   }
+}
 
+export async function fetchEtablissements(
+  options: FetchOptions
+): Promise<Etablissement[]> {
+  const all: Etablissement[] = [];
+  for await (const etab of streamEtablissements(options)) {
+    all.push(etab);
+  }
   return all;
 }

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -54,6 +54,7 @@ export interface Etablissement {
 export interface FetchOptions {
   region?: string;
   departement?: string;
+  limit?: number;
 }
 
 // --- Helpers ---
@@ -214,7 +215,8 @@ function mapEtablissement(raw: SireneEtablissement): Etablissement {
 async function fetchForNaf(
   nafCode: string,
   departements: string[] | null,
-  headers: Record<string, string>
+  headers: Record<string, string>,
+  limit?: number
 ): Promise<Etablissement[]> {
   const query = buildQuery(nafCode, departements);
   const etablissements: Etablissement[] = [];
@@ -236,6 +238,7 @@ async function fetchForNaf(
 
     for (const raw of data.etablissements) {
       etablissements.push(mapEtablissement(raw));
+      if (limit !== undefined && etablissements.length >= limit) return etablissements;
     }
 
     const next = data.header.curseurSuivant;
@@ -261,9 +264,11 @@ export async function fetchEtablissements(
 
   const departements = getDepartements(options);
 
+  const { limit } = options;
+
   // Un appel par code NAF (OR interdit dans periode())
   const results = await Promise.all(
-    NAF_CODES.map((naf) => fetchForNaf(naf, departements, headers))
+    NAF_CODES.map((naf) => fetchForNaf(naf, departements, headers, limit))
   );
 
   // Dédoublonnage par SIRET (un établissement peut matcher les deux NAF)
@@ -274,6 +279,7 @@ export async function fetchEtablissements(
       if (!seen.has(e.siret)) {
         seen.add(e.siret);
         all.push(e);
+        if (limit !== undefined && all.length >= limit) return all;
       }
     }
   }


### PR DESCRIPTION
## Contexte

Implémente `src/pipeline.ts` (#6) — orchestration séquentielle des établissements SIRENE : déduplication → enrichissement téléphone → insertion en base → stats.

## Changements

- **`src/pipeline.ts`** — implémentation de `runPipeline` :
  - Skip immédiat si `isKnown(siret)` (aucun appel réseau)
  - Enrichissement Google Maps, fallback Pages Jaunes (stub, issue #5 à venir)
  - Accepte un `AsyncIterable<Etablissement>` ou un tableau — stream lazy depuis SIRENE
  - `prospects` ne contient que les établissements avec numéro trouvé
  - Limite optionnelle : s'arrête après N nouveaux (les déjà connus ne comptent pas)
  - Traitement séquentiel

- **`src/dedup.ts`** — extension du schéma pour couvrir l'export CSV complet :
  - `ScrapedRecord` étendu : `adresse`, `codePostal`, `effectifTranche`
  - Schéma SQLite mis à jour : `adresse`, `code_postal`, `effectif_tranche`
  - Requêtes `INSERT`, `getAll`, `getPaginated` alignées

- **`src/sirene.ts`** — streaming lazy page par page :
  - `streamEtablissements()` générateur async — yield un établissement à la fois
  - SIRENE s'arrête de paginer dès que le pipeline a assez de nouveaux
  - `fetchEtablissements()` conservée (consomme le stream, usage sans limite)

- **`src/server.ts`** — connecté au pipeline :
  - `POST /api/scrape` accepte `limit` (clampé 1–10 000, validé)
  - Avec limite → stream lazy ; sans limite → fetch complet
  - Export CSV aligné sur les 9 colonnes (`adresse`, `code_postal`, `effectif_tranche`)

- **`src/public/index.html`** — champ "Limite" dans le formulaire de scrape

## Critères d'acceptance

- [x] Un établissement déjà en base est skippé sans appel réseau
- [x] Fallback Pages Jaunes déclenché uniquement si Google retourne `null`
- [x] Les stats `nouveaux / alreadyKnown / nonTrouves` sont exactes
- [x] La limite porte sur les nouveaux uniquement (les doublons connus ne comptent pas)
- [x] Avec limite : 1 seule page SIRENE au lieu de 70
- [x] `npx tsc --noEmit` passe

## Notes

- `findPhonePJ` est un stub retournant `null` (issue #5 à venir)
- Le schéma SQLite inclut tous les champs nécessaires à l'export CSV