### PR TITLE
[Feat] Filtre téléphone mobile et page filtres avancés

### DIFF
--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -89,7 +89,7 @@ export function getStats(): ScrapedStats {
         COUNT(*) as total,
         COUNT(CASE WHEN source != 'non_trouvé' THEN 1 END) as found,
         COUNT(CASE WHEN source = 'non_trouvé' THEN 1 END) as notFound,
-        COUNT(CASE WHEN ${mobileCond} THEN 1 END) as mobile
+        COUNT(CASE WHEN source != 'non_trouvé' AND ${mobileCond} THEN 1 END) as mobile
       FROM scraped`
     )
     .get() as { total: number; found: number; notFound: number; mobile: number };

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -28,6 +28,53 @@ export interface PaginatedResult<T> {
   totalPages: number;
 }
 
+export interface ResultFilters {
+  sourceFilter?: "found" | "non_trouvé";
+  sourceExact?:  "google" | "pagesjaunes" | "non_trouvé";
+  nom?:          string;
+  ville?:        string;
+  phoneType?:    "mobile" | "fixe";
+  effectif?:     string;
+  departement?:  string;
+}
+
+export interface FilterOptions {
+  villes:       string[];
+  sources:      string[];
+  effectifs:    Array<{ value: string; label: string }>;
+  departements: string[];
+}
+
+const EFFECTIF_LABELS: Record<string, string> = {
+  "11": "10-19 sal.",
+  "12": "10-19 sal.",
+  "21": "20-49 sal.",
+  "22": "50-99 sal.",
+  "31": "100+ sal.",
+};
+
+function buildWhereClause(filters: ResultFilters): { where: string; params: unknown[] } {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (filters.sourceExact) {
+    conditions.push("source = ?");
+    params.push(filters.sourceExact);
+  } else if (filters.sourceFilter === "found") {
+    conditions.push("source != 'non_trouvé'");
+  } else if (filters.sourceFilter === "non_trouvé") {
+    conditions.push("source = 'non_trouvé'");
+  }
+
+  if (filters.phoneType) conditions.push(phoneTypeCondition(filters.phoneType));
+  if (filters.nom?.trim())         { conditions.push("nom LIKE ?");             params.push("%" + filters.nom.trim() + "%"); }
+  if (filters.ville?.trim())       { conditions.push("ville LIKE ?");           params.push("%" + filters.ville.trim() + "%"); }
+  if (filters.effectif?.trim())    { conditions.push("effectif_tranche = ?");   params.push(filters.effectif.trim()); }
+  if (filters.departement?.trim()) { conditions.push("code_postal LIKE ?");     params.push(filters.departement.trim() + "%"); }
+
+  return { where: conditions.length ? "WHERE " + conditions.join(" AND ") : "", params };
+}
+
 const DB_PATH = path.join(__dirname, "..", "data", "scraper.db");
 
 let db: Database.Database | undefined;
@@ -114,12 +161,8 @@ export function updateRecord(siret: string, telephone: string, source: string): 
     .run(telephone, source, new Date().toISOString(), siret);
 }
 
-export function getAll(phoneType?: "mobile" | "fixe", ville?: string): ScrapedRecord[] {
-  const conditions: string[] = [];
-  const params: unknown[] = [];
-  if (phoneType) conditions.push(phoneTypeCondition(phoneType));
-  if (ville && ville.trim()) { conditions.push("ville LIKE ?"); params.push("%" + ville.trim() + "%"); }
-  const where = conditions.length ? "WHERE " + conditions.join(" AND ") : "";
+export function getAll(filters: ResultFilters = {}): ScrapedRecord[] {
+  const { where, params } = buildWhereClause(filters);
   return requireDb()
     .prepare(`SELECT ${SELECT_FIELDS} FROM scraped ${where} ORDER BY scraped_at DESC`)
     .all(params) as ScrapedRecord[];
@@ -128,33 +171,11 @@ export function getAll(phoneType?: "mobile" | "fixe", ville?: string): ScrapedRe
 export function getPaginated(
   page: number,
   limit: number,
-  sourceFilter?: "found" | "non_trouvé",
-  nom?: string,
-  phoneType?: "mobile" | "fixe",
-  ville?: string
+  filters: ResultFilters = {}
 ): PaginatedResult<ScrapedRecord> {
   if (limit < 1) throw new Error("limit doit être >= 1");
   const conn = requireDb();
-
-  const conditions: string[] = [];
-  const params: unknown[] = [];
-
-  if (sourceFilter === "found")      conditions.push("source != 'non_trouvé'");
-  if (sourceFilter === "non_trouvé") conditions.push("source = 'non_trouvé'");
-
-  if (phoneType) conditions.push(phoneTypeCondition(phoneType));
-
-  if (nom && nom.trim()) {
-    conditions.push("nom LIKE ?");
-    params.push("%" + nom.trim() + "%");
-  }
-
-  if (ville && ville.trim()) {
-    conditions.push("ville LIKE ?");
-    params.push("%" + ville.trim() + "%");
-  }
-
-  const where = conditions.length ? "WHERE " + conditions.join(" AND ") : "";
+  const { where, params } = buildWhereClause(filters);
 
   const { count } = conn
     .prepare(`SELECT COUNT(*) as count FROM scraped ${where}`)
@@ -166,4 +187,27 @@ export function getPaginated(
     .prepare(`SELECT ${SELECT_FIELDS} FROM scraped ${where} ORDER BY scraped_at DESC LIMIT ? OFFSET ?`)
     .all([...params, limit, offset]) as ScrapedRecord[];
   return { data, total: count, page: safePage, totalPages };
+}
+
+export function getFilterOptions(): FilterOptions {
+  const conn = requireDb();
+
+  const villes = (conn
+    .prepare("SELECT DISTINCT ville FROM scraped WHERE ville IS NOT NULL AND ville != '' ORDER BY ville")
+    .all() as { ville: string }[]).map(r => r.ville);
+
+  const sources = (conn
+    .prepare("SELECT DISTINCT source FROM scraped WHERE source IS NOT NULL ORDER BY source")
+    .all() as { source: string }[]).map(r => r.source);
+
+  const effectifs = (conn
+    .prepare("SELECT DISTINCT effectif_tranche FROM scraped WHERE effectif_tranche IS NOT NULL ORDER BY effectif_tranche")
+    .all() as { effectif_tranche: string }[])
+    .map(r => ({ value: r.effectif_tranche, label: EFFECTIF_LABELS[r.effectif_tranche] ?? r.effectif_tranche }));
+
+  const departements = (conn
+    .prepare("SELECT DISTINCT SUBSTR(code_postal, 1, 2) as dep FROM scraped WHERE code_postal IS NOT NULL AND code_postal != '' ORDER BY dep")
+    .all() as { dep: string }[]).map(r => r.dep);
+
+  return { villes, sources, effectifs, departements };
 }

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import path from "path";
+import { phoneTypeCondition } from "./phoneUtils";
 
 export interface ScrapedRecord {
   siret: string;
@@ -17,6 +18,7 @@ export interface ScrapedStats {
   total: number;
   found: number;
   notFound: number;
+  mobile: number;
 }
 
 export interface PaginatedResult<T> {
@@ -80,16 +82,18 @@ export function insert(record: ScrapedRecord): void {
 }
 
 export function getStats(): ScrapedStats {
+  const mobileCond = phoneTypeCondition("mobile");
   const row = requireDb()
     .prepare(
       `SELECT
         COUNT(*) as total,
         COUNT(CASE WHEN source != 'non_trouvé' THEN 1 END) as found,
-        COUNT(CASE WHEN source = 'non_trouvé' THEN 1 END) as notFound
+        COUNT(CASE WHEN source = 'non_trouvé' THEN 1 END) as notFound,
+        COUNT(CASE WHEN ${mobileCond} THEN 1 END) as mobile
       FROM scraped`
     )
-    .get() as { total: number; found: number; notFound: number };
-  return { total: row.total, found: row.found, notFound: row.notFound };
+    .get() as { total: number; found: number; notFound: number; mobile: number };
+  return { total: row.total, found: row.found, notFound: row.notFound, mobile: row.mobile };
 }
 
 const SELECT_FIELDS = `
@@ -110,9 +114,10 @@ export function updateRecord(siret: string, telephone: string, source: string): 
     .run(telephone, source, new Date().toISOString(), siret);
 }
 
-export function getAll(): ScrapedRecord[] {
+export function getAll(phoneType?: "mobile" | "fixe"): ScrapedRecord[] {
+  const where = phoneType ? `WHERE ${phoneTypeCondition(phoneType)}` : "";
   return requireDb()
-    .prepare(`SELECT ${SELECT_FIELDS} FROM scraped ORDER BY scraped_at DESC`)
+    .prepare(`SELECT ${SELECT_FIELDS} FROM scraped ${where} ORDER BY scraped_at DESC`)
     .all() as ScrapedRecord[];
 }
 
@@ -120,7 +125,8 @@ export function getPaginated(
   page: number,
   limit: number,
   sourceFilter?: "found" | "non_trouvé",
-  search?: string
+  search?: string,
+  phoneType?: "mobile" | "fixe"
 ): PaginatedResult<ScrapedRecord> {
   if (limit < 1) throw new Error("limit doit être >= 1");
   const conn = requireDb();
@@ -130,6 +136,8 @@ export function getPaginated(
 
   if (sourceFilter === "found")      conditions.push("source != 'non_trouvé'");
   if (sourceFilter === "non_trouvé") conditions.push("source = 'non_trouvé'");
+
+  if (phoneType) conditions.push(phoneTypeCondition(phoneType));
 
   if (search && search.trim()) {
     const like = "%" + search.trim() + "%";

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -114,19 +114,24 @@ export function updateRecord(siret: string, telephone: string, source: string): 
     .run(telephone, source, new Date().toISOString(), siret);
 }
 
-export function getAll(phoneType?: "mobile" | "fixe"): ScrapedRecord[] {
-  const where = phoneType ? `WHERE ${phoneTypeCondition(phoneType)}` : "";
+export function getAll(phoneType?: "mobile" | "fixe", ville?: string): ScrapedRecord[] {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  if (phoneType) conditions.push(phoneTypeCondition(phoneType));
+  if (ville && ville.trim()) { conditions.push("ville LIKE ?"); params.push("%" + ville.trim() + "%"); }
+  const where = conditions.length ? "WHERE " + conditions.join(" AND ") : "";
   return requireDb()
     .prepare(`SELECT ${SELECT_FIELDS} FROM scraped ${where} ORDER BY scraped_at DESC`)
-    .all() as ScrapedRecord[];
+    .all(params) as ScrapedRecord[];
 }
 
 export function getPaginated(
   page: number,
   limit: number,
   sourceFilter?: "found" | "non_trouvé",
-  search?: string,
-  phoneType?: "mobile" | "fixe"
+  nom?: string,
+  phoneType?: "mobile" | "fixe",
+  ville?: string
 ): PaginatedResult<ScrapedRecord> {
   if (limit < 1) throw new Error("limit doit être >= 1");
   const conn = requireDb();
@@ -139,10 +144,14 @@ export function getPaginated(
 
   if (phoneType) conditions.push(phoneTypeCondition(phoneType));
 
-  if (search && search.trim()) {
-    const like = "%" + search.trim() + "%";
-    conditions.push("(nom LIKE ? OR ville LIKE ?)");
-    params.push(like, like);
+  if (nom && nom.trim()) {
+    conditions.push("nom LIKE ?");
+    params.push("%" + nom.trim() + "%");
+  }
+
+  if (ville && ville.trim()) {
+    conditions.push("ville LIKE ?");
+    params.push("%" + ville.trim() + "%");
   }
 
   const where = conditions.length ? "WHERE " + conditions.join(" AND ") : "";

--- a/src/phoneUtils.ts
+++ b/src/phoneUtils.ts
@@ -3,9 +3,11 @@ export type PhoneType = "mobile" | "fixe" | null;
 export function classifyPhone(phone: string | null): PhoneType {
   if (!phone) return null;
   const cleaned = phone.replace(/[\s.+()-]/g, "");
+  // Normalise +33XXXXXXXXX, 33XXXXXXXXX et 0033XXXXXXXXX vers 0XXXXXXXXX
+  const withoutCountryCode = cleaned.replace(/^00/, "");
   const normalized =
-    cleaned.startsWith("33") && cleaned.length === 11
-      ? "0" + cleaned.slice(2)
+    withoutCountryCode.startsWith("33") && withoutCountryCode.length === 11
+      ? "0" + withoutCountryCode.slice(2)
       : cleaned;
   if (/^0[67]/.test(normalized)) return "mobile";
   if (/^0[1-59]/.test(normalized)) return "fixe";

--- a/src/phoneUtils.ts
+++ b/src/phoneUtils.ts
@@ -1,0 +1,20 @@
+export type PhoneType = "mobile" | "fixe" | null;
+
+export function classifyPhone(phone: string | null): PhoneType {
+  if (!phone) return null;
+  const cleaned = phone.replace(/[\s.+()-]/g, "");
+  const normalized =
+    cleaned.startsWith("33") && cleaned.length === 11
+      ? "0" + cleaned.slice(2)
+      : cleaned;
+  if (/^0[67]/.test(normalized)) return "mobile";
+  if (/^0[1-59]/.test(normalized)) return "fixe";
+  return null;
+}
+
+const MOBILE_SQL = "(telephone LIKE '06%' OR telephone LIKE '07%' OR telephone LIKE '+336%' OR telephone LIKE '+337%' OR telephone LIKE '336%' OR telephone LIKE '337%')";
+
+export function phoneTypeCondition(phoneType: "mobile" | "fixe"): string {
+  if (phoneType === "mobile") return MOBILE_SQL;
+  return `(telephone IS NOT NULL AND telephone != '' AND NOT ${MOBILE_SQL})`;
+}

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -595,6 +595,102 @@
     .toast.success { border-color: rgba(34,197,94,0.3); color: var(--success); }
     .toast.warn    { border-color: rgba(245,158,11,0.3); color: var(--warn); }
     .toast.error   { border-color: rgba(239,68,68,0.3); color: #f87171; }
+
+    /* ── NAVIGATION VUES ── */
+    .nav-tabs {
+      display: flex;
+      gap: 0;
+      border: 1px solid var(--border-hover);
+      border-radius: 5px;
+      overflow: hidden;
+    }
+
+    .nav-tab {
+      flex: 1;
+      background: transparent;
+      border: none;
+      border-right: 1px solid var(--border-hover);
+      color: var(--muted);
+      padding: 0.45rem 0;
+      font-family: var(--mono);
+      font-size: 0.62rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s;
+      user-select: none;
+    }
+
+    .nav-tab:last-child { border-right: none; }
+    .nav-tab.active { background: var(--accent); color: #fff; }
+    .nav-tab:hover:not(.active) { background: var(--bg-elevated); color: var(--text); }
+
+    /* ── VUES ── */
+    .view { display: none; flex: 1; flex-direction: column; overflow: hidden; height: 100%; }
+    .view.active { display: flex; }
+
+    /* ── FILTRES AVANCÉS ── */
+    .filter-bar {
+      flex-shrink: 0;
+      padding: 0.75rem 1.5rem 0.6rem;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+
+    .filter-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      align-items: flex-end;
+    }
+
+    .filter-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.28rem;
+      min-width: 110px;
+    }
+
+    .filter-field--wide { min-width: 180px; flex: 1; }
+    .filter-field--btn  { justify-content: flex-end; }
+
+    .filter-field > label {
+      font-size: 0.56rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .filter-footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 0.5rem;
+      padding-top: 0.45rem;
+      border-top: 1px solid var(--border);
+    }
+
+    .filter-count {
+      font-size: 0.64rem;
+      color: var(--muted);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .filter-count strong { color: var(--text); }
+
+    .btn-reset {
+      background: transparent;
+      color: var(--muted);
+      border: 1px solid var(--border-hover);
+      padding: 0.38rem 0.75rem;
+      border-radius: 5px;
+      font-family: var(--mono);
+      font-size: 0.62rem;
+      cursor: pointer;
+      transition: color 0.15s, border-color 0.15s;
+    }
+
+    .btn-reset:hover { color: var(--text); border-color: var(--muted); }
   </style>
 </head>
 <body>
@@ -607,6 +703,14 @@
       <div class="status-chip">
         <span class="status-dot" id="statusDot"></span>
         <span id="statusText">En attente</span>
+      </div>
+    </div>
+
+    <!-- Navigation vues -->
+    <div class="s-section">
+      <div class="nav-tabs">
+        <button class="nav-tab active" id="navResults" onclick="setView('results')">Résultats</button>
+        <button class="nav-tab"        id="navFilters" onclick="setView('filters')">Filtres</button>
       </div>
     </div>
 
@@ -693,6 +797,9 @@
   <!-- ── MAIN ── -->
   <main class="main">
 
+  <!-- Vue Résultats -->
+  <div class="view active" id="view-results">
+
     <div class="stats-bar">
       <div class="stat active" id="tab-all" onclick="setFilter('all')">
         <div class="stat-label">Total</div>
@@ -754,6 +861,91 @@
       </table>
     </div>
 
+  </div><!-- /view-results -->
+
+  <!-- Vue Filtres avancés -->
+  <div class="view" id="view-filters">
+
+    <div class="filter-bar">
+      <div class="filter-row">
+
+        <div class="filter-field filter-field--wide">
+          <label>Nom</label>
+          <div class="search-wrap" style="flex:none;width:100%">
+            <span class="search-icon">⌕</span>
+            <input type="text" class="search-input" id="fNom" placeholder="Nom de l'établissement…" oninput="onAdvFilter()">
+          </div>
+        </div>
+
+        <div class="filter-field">
+          <label>Ville</label>
+          <select id="fVille" onchange="onAdvFilter()">
+            <option value="">Toutes</option>
+          </select>
+        </div>
+
+        <div class="filter-field">
+          <label>Département</label>
+          <select id="fDep" onchange="onAdvFilter()">
+            <option value="">Tous</option>
+          </select>
+        </div>
+
+        <div class="filter-field">
+          <label>Source</label>
+          <select id="fSource" onchange="onAdvFilter()">
+            <option value="">Toutes</option>
+            <option value="google">Google</option>
+            <option value="pagesjaunes">Pages Jaunes</option>
+            <option value="non_trouvé">Non trouvé</option>
+          </select>
+        </div>
+
+        <div class="filter-field">
+          <label>Effectif</label>
+          <select id="fEffectif" onchange="onAdvFilter()">
+            <option value="">Tous</option>
+          </select>
+        </div>
+
+        <div class="filter-field">
+          <label>Téléphone</label>
+          <select id="fPhoneType" onchange="onAdvFilter()">
+            <option value="">Tous</option>
+            <option value="mobile">Mobile (06/07)</option>
+            <option value="fixe">Fixe</option>
+          </select>
+        </div>
+
+        <div class="filter-field filter-field--btn">
+          <button class="btn-reset" onclick="resetAdvFilters()">✕ Réinitialiser</button>
+        </div>
+
+      </div>
+
+      <div class="filter-footer">
+        <span class="filter-count" id="advFilterCount">—</span>
+        <button class="btn-export" onclick="exportAdvCsv()">↓ &nbsp;Exporter CSV</button>
+      </div>
+    </div>
+
+    <div class="table-area">
+      <table>
+        <thead>
+          <tr>
+            <th>Établissement</th>
+            <th>Ville</th>
+            <th>CP</th>
+            <th>Effectif</th>
+            <th title="Cliquer pour copier">Téléphone</th>
+            <th>Source</th>
+          </tr>
+        </thead>
+        <tbody id="advResultsBody"></tbody>
+      </table>
+    </div>
+
+  </div><!-- /view-filters -->
 
   </main>
 
@@ -767,6 +959,10 @@
     let retryPollInterval = null;
     let activeFilter      = "all";
     let exportScope       = "all";
+    let activeView        = "results";
+    let advFilterTimeout  = null;
+
+    const EFFECTIF_LABELS = { "11":"10-19 sal.","12":"10-19 sal.","21":"20-49 sal.","22":"50-99 sal.","31":"100+ sal." };
     let activeScope       = "region";
     let filterTimeout     = null;
     let nomQuery          = "";
@@ -808,6 +1004,120 @@
       });
       document.getElementById("field-region").style.display = s === "region" ? "" : "none";
       document.getElementById("field-dep").style.display    = s === "dep"    ? "" : "none";
+    }
+
+    /* ── Navigation vues ── */
+    function setView(view) {
+      activeView = view;
+      document.getElementById("view-results").classList.toggle("active", view === "results");
+      document.getElementById("view-filters").classList.toggle("active", view === "filters");
+      document.getElementById("navResults").classList.toggle("active", view === "results");
+      document.getElementById("navFilters").classList.toggle("active", view === "filters");
+      if (view === "filters") fetchAdvResults();
+    }
+
+    /* ── Filtres avancés ── */
+    function buildAdvParams() {
+      var params = [];
+      var nom    = document.getElementById("fNom").value.trim();
+      var ville  = document.getElementById("fVille").value;
+      var dep    = document.getElementById("fDep").value;
+      var src    = document.getElementById("fSource").value;
+      var eff    = document.getElementById("fEffectif").value;
+      var phone  = document.getElementById("fPhoneType").value;
+      if (nom)   params.push("nom="         + encodeURIComponent(nom));
+      if (ville) params.push("ville="       + encodeURIComponent(ville));
+      if (dep)   params.push("departement=" + encodeURIComponent(dep));
+      if (src)   params.push("sourceExact=" + encodeURIComponent(src));
+      if (eff)   params.push("effectif="    + encodeURIComponent(eff));
+      if (phone) params.push("phoneType="   + encodeURIComponent(phone));
+      return params;
+    }
+
+    async function fetchAdvResults() {
+      var params = buildAdvParams();
+      var url = "/api/results?page=1&limit=5000" + (params.length ? "&" + params.join("&") : "");
+      var data = await fetch(url).then(function(r) { return r.json(); });
+
+      var count = data.total;
+      document.getElementById("advFilterCount").innerHTML =
+        "<strong>" + count.toLocaleString("fr-FR") + "</strong> résultat" + (count !== 1 ? "s" : "");
+
+      var tbody = document.getElementById("advResultsBody");
+      tbody.innerHTML = "";
+
+      if (!data.data.length) {
+        tbody.innerHTML = '<tr><td colspan="6"><div class="empty"><strong>Aucun résultat</strong>Modifiez les filtres pour afficher des résultats.</div></td></tr>';
+        return;
+      }
+
+      data.data.forEach(function(r) {
+        var bc = r.source === "google" ? "b-google" : r.source === "pagesjaunes" ? "b-pagesjaunes" : "b-non";
+        var sl = r.source === "non_trouvé" ? "non trouvé" : r.source;
+
+        var tdNom  = document.createElement("td"); tdNom.className  = "col-nom";   tdNom.textContent  = r.nom;   tdNom.title = r.nom;
+        var tdVille = document.createElement("td"); tdVille.className = "col-ville"; tdVille.textContent = r.ville || "—";
+        var tdCp   = document.createElement("td"); tdCp.className   = "col-ville"; tdCp.textContent   = r.codePostal || "—";
+        var tdEff  = document.createElement("td"); tdEff.className  = "col-ville"; tdEff.textContent  = EFFECTIF_LABELS[r.effectifTranche] || r.effectifTranche || "—";
+
+        var phone = r.telephone || "—";
+        var tdTel = document.createElement("td"); tdTel.className = "col-tel";
+        if (r.telephone) {
+          var sp = document.createElement("span"); sp.textContent = phone; tdTel.appendChild(sp);
+          var tag = document.createElement("span");
+          var mob = isMobile(r.telephone);
+          tag.className = "phone-tag " + (mob ? "mobile" : "fixe");
+          tag.textContent = mob ? "mobile" : "fixe";
+          tdTel.appendChild(tag);
+          tdTel.title = "Cliquer pour copier";
+          (function(t, p) { t.addEventListener("click", function() { copyPhone(t, p); }); })(tdTel, phone);
+        } else { tdTel.textContent = "—"; }
+
+        var badge = document.createElement("span"); badge.className = "badge " + bc; badge.textContent = sl;
+        var tdSrc = document.createElement("td"); tdSrc.appendChild(badge);
+
+        var tr = document.createElement("tr");
+        tr.append(tdNom, tdVille, tdCp, tdEff, tdTel, tdSrc);
+        tbody.appendChild(tr);
+      });
+    }
+
+    function onAdvFilter() {
+      clearTimeout(advFilterTimeout);
+      advFilterTimeout = setTimeout(fetchAdvResults, 280);
+    }
+
+    function resetAdvFilters() {
+      ["fNom","fVille","fDep","fSource","fEffectif","fPhoneType"].forEach(function(id) {
+        document.getElementById(id).value = "";
+      });
+      fetchAdvResults();
+    }
+
+    function exportAdvCsv() {
+      var params = buildAdvParams();
+      var url = "/api/export" + (params.length ? "?" + params.join("&") : "");
+      window.location = url;
+      toast("Téléchargement du CSV…");
+    }
+
+    async function fetchFilterOptions() {
+      var opts = await fetch("/api/filters").then(function(r) { return r.json(); });
+
+      var selVille = document.getElementById("fVille");
+      opts.villes.forEach(function(v) {
+        var o = document.createElement("option"); o.value = v; o.textContent = v; selVille.appendChild(o);
+      });
+
+      var selDep = document.getElementById("fDep");
+      opts.departements.forEach(function(d) {
+        var o = document.createElement("option"); o.value = d; o.textContent = "Dép. " + d; selDep.appendChild(o);
+      });
+
+      var selEff = document.getElementById("fEffectif");
+      opts.effectifs.forEach(function(e) {
+        var o = document.createElement("option"); o.value = e.value; o.textContent = e.label; selEff.appendChild(o);
+      });
     }
 
     /* ── Filter ── */
@@ -1084,6 +1394,7 @@
     fetchStats();
     fetchResults();
     fetchRegions();
+    fetchFilterOptions();
     pollStatus();
 
     /* Auto-refresh résultats toutes les 10s si idle */

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -520,6 +520,23 @@
     .b-pagesjaunes { background: var(--warn-dim);    color: var(--warn);    border-color: rgba(245,158,11,0.18); }
     .b-non         { background: var(--bg-elevated); color: var(--muted);   border-color: var(--border); }
 
+    .phone-tag {
+      display: inline-block;
+      padding: 0.1rem 0.35rem;
+      border-radius: 3px;
+      font-size: 0.52rem;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      margin-left: 0.4rem;
+      vertical-align: middle;
+    }
+
+    .phone-tag.mobile { background: rgba(99,102,241,0.12); color: #818cf8; border: 1px solid rgba(99,102,241,0.2); }
+    .phone-tag.fixe   { background: var(--bg-elevated); color: var(--dim); border: 1px solid var(--border); }
+
+    .stat#tab-mobile .stat-value { color: #818cf8; }
+    .stat#tab-mobile.active::after { background: linear-gradient(90deg, #818cf8 0%, transparent 100%); }
+
     /* ── TOAST ── */
     .toast-container {
       position: fixed;
@@ -647,8 +664,12 @@
         <div class="stat-value" id="statTotal">0</div>
       </div>
       <div class="stat" id="tab-found" onclick="setFilter('found')">
-        <div class="stat-label">Avec téléphone</div>
+        <div class="stat-label">Avec t��léphone</div>
         <div class="stat-value" id="statFound">0</div>
+      </div>
+      <div class="stat" id="tab-mobile" onclick="toggleMobile()">
+        <div class="stat-label">Mobile</div>
+        <div class="stat-value" id="statMobile">0</div>
       </div>
       <div class="stat" id="tab-notfound" onclick="setFilter('notfound')">
         <div class="stat-label">Non trouvés</div>
@@ -700,6 +721,7 @@
     let pollInterval      = null;
     let retryPollInterval = null;
     let activeFilter      = "all";
+    let phoneTypeFilter   = null;
     let activeScope       = "region";
     let searchTimeout     = null;
     let searchQuery       = "";
@@ -754,6 +776,20 @@
       fetchResults();
     }
 
+    /* ── Phone type ── */
+    function isMobile(phone) {
+      if (!phone) return false;
+      var cleaned = phone.replace(/[\s.+()-]/g, "");
+      var norm = cleaned.startsWith("33") && cleaned.length === 11 ? "0" + cleaned.slice(2) : cleaned;
+      return /^0[67]/.test(norm);
+    }
+
+    function toggleMobile() {
+      phoneTypeFilter = phoneTypeFilter === "mobile" ? null : "mobile";
+      document.getElementById("tab-mobile").classList.toggle("active", phoneTypeFilter === "mobile");
+      fetchResults();
+    }
+
     /* ── Search ── */
     function onSearch() {
       clearTimeout(searchTimeout);
@@ -780,6 +816,7 @@
       const s = await fetch("/api/stats").then(r => r.json());
       counter(document.getElementById("statTotal"),    s.total);
       counter(document.getElementById("statFound"),    s.found);
+      counter(document.getElementById("statMobile"),   s.mobile || 0);
       counter(document.getElementById("statNotFound"), s.notFound);
     }
 
@@ -798,6 +835,7 @@
       let url = "/api/results?page=1&limit=5000";
       if (activeFilter === "found")    url += "&source=found";
       if (activeFilter === "notfound") url += "&source=non_trouv%C3%A9";
+      if (phoneTypeFilter) url += "&phoneType=" + phoneTypeFilter;
       if (searchQuery) url += "&q=" + encodeURIComponent(searchQuery);
 
       const data = await fetch(url).then(r => r.json());
@@ -823,6 +861,11 @@
             const sp = document.createElement("span");
             sp.textContent = phone;
             tdTel.appendChild(sp);
+            var tag = document.createElement("span");
+            var mob = isMobile(r.telephone);
+            tag.className = "phone-tag " + (mob ? "mobile" : "fixe");
+            tag.textContent = mob ? "mobile" : "fixe";
+            tdTel.appendChild(tag);
             tdTel.title = "Cliquer pour copier";
             tdTel.addEventListener("click", function() { copyPhone(tdTel, phone); });
           } else {
@@ -976,7 +1019,9 @@
     }
 
     function exportCsv() {
-      window.location = "/api/export";
+      var url = "/api/export";
+      if (phoneTypeFilter) url += "?phoneType=" + phoneTypeFilter;
+      window.location = url;
       toast("Téléchargement du CSV…");
     }
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -316,6 +316,34 @@
       margin-top: auto;
     }
 
+    .export-scope {
+      display: flex;
+      gap: 0;
+      border: 1px solid var(--border-hover);
+      border-radius: 5px;
+      overflow: hidden;
+      margin-bottom: 0.5rem;
+    }
+
+    .export-scope button {
+      flex: 1;
+      background: transparent;
+      border: none;
+      border-right: 1px solid var(--border-hover);
+      color: var(--muted);
+      padding: 0.35rem 0;
+      font-family: var(--mono);
+      font-size: 0.6rem;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s;
+      user-select: none;
+    }
+
+    .export-scope button:last-child { border-right: none; }
+    .export-scope button:hover { background: var(--bg-elevated); color: var(--text); }
+    .export-scope button.active { background: var(--accent); color: #fff; }
+
     .btn-export {
       width: 100%;
       background: transparent;
@@ -650,6 +678,11 @@
     </div>
 
     <div class="sidebar-footer">
+      <div class="export-scope" id="exportScopeToggle">
+        <button id="exportScopeAll"    class="active" onclick="setExportScope('all')">Tout</button>
+        <button id="exportScopeMobile"            onclick="setExportScope('mobile')">Mobile</button>
+        <button id="exportScopeFixe"              onclick="setExportScope('fixe')">Fixe</button>
+      </div>
       <button class="btn-export" onclick="exportCsv()">↓ &nbsp;Exporter CSV</button>
     </div>
 
@@ -722,6 +755,7 @@
     let retryPollInterval = null;
     let activeFilter      = "all";
     let phoneTypeFilter   = null;
+    let exportScope       = "all";
     let activeScope       = "region";
     let searchTimeout     = null;
     let searchQuery       = "";
@@ -1018,11 +1052,20 @@
       }
     }
 
+    function setExportScope(scope) {
+      exportScope = scope;
+      ["all", "mobile", "fixe"].forEach(function(s) {
+        document.getElementById("exportScope" + s.charAt(0).toUpperCase() + s.slice(1))
+          .classList.toggle("active", s === scope);
+      });
+    }
+
     function exportCsv() {
       var url = "/api/export";
-      if (phoneTypeFilter) url += "?phoneType=" + phoneTypeFilter;
+      if (exportScope !== "all") url += "?phoneType=" + exportScope;
       window.location = url;
-      toast("Téléchargement du CSV…");
+      var labels = { all: "Téléchargement du CSV…", mobile: "Export mobiles…", fixe: "Export fixes…" };
+      toast(labels[exportScope] || "Téléchargement du CSV…");
     }
 
     /* ── Init ── */

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -431,8 +431,10 @@
 
     .search-wrap {
       position: relative;
-      flex: 1;
+      flex: 2;
     }
+
+    .search-wrap.ville { flex: 1; }
 
     .search-icon {
       position: absolute;
@@ -720,9 +722,19 @@
         <input
           type="text"
           class="search-input"
-          id="searchInput"
-          placeholder="Rechercher un établissement ou une ville…"
-          oninput="onSearch()"
+          id="searchNom"
+          placeholder="Nom de l'établissement…"
+          oninput="onFilter()"
+        >
+      </div>
+      <div class="search-wrap ville">
+        <span class="search-icon">⌕</span>
+        <input
+          type="text"
+          class="search-input"
+          id="searchVille"
+          placeholder="Ville…"
+          oninput="onFilter()"
         >
       </div>
       <span class="filter-label" id="filterLabel"></span>
@@ -756,8 +768,9 @@
     let activeFilter      = "all";
     let exportScope       = "all";
     let activeScope       = "region";
-    let searchTimeout     = null;
-    let searchQuery       = "";
+    let filterTimeout     = null;
+    let nomQuery          = "";
+    let villeQuery        = "";
 
     /* ── Toast ── */
     function toast(msg, type = "") {
@@ -817,11 +830,12 @@
       return /^0[67]/.test(norm);
     }
 
-    /* ── Search ── */
-    function onSearch() {
-      clearTimeout(searchTimeout);
-      searchTimeout = setTimeout(function() {
-        searchQuery = document.getElementById("searchInput").value.trim();
+    /* ── Filtres texte ── */
+    function onFilter() {
+      clearTimeout(filterTimeout);
+      filterTimeout = setTimeout(function() {
+        nomQuery   = document.getElementById("searchNom").value.trim();
+        villeQuery = document.getElementById("searchVille").value.trim();
         fetchResults();
       }, 280);
     }
@@ -863,7 +877,8 @@
       if (activeFilter === "found")    url += "&source=found";
       if (activeFilter === "notfound") url += "&source=non_trouv%C3%A9";
       if (activeFilter === "mobile")   url += "&phoneType=mobile";
-      if (searchQuery) url += "&q=" + encodeURIComponent(searchQuery);
+      if (nomQuery)   url += "&nom="   + encodeURIComponent(nomQuery);
+      if (villeQuery) url += "&ville=" + encodeURIComponent(villeQuery);
 
       const data = await fetch(url).then(r => r.json());
 
@@ -871,7 +886,9 @@
       tbody.innerHTML = "";
 
       if (!data.data.length) {
-        const msg = searchQuery ? "Aucun résultat pour «\u00a0" + searchQuery + "\u00a0»" : "Lancez un scrape pour commencer la prospection.";
+        var hasFilter = nomQuery || villeQuery;
+        var filterDesc = [nomQuery ? "nom\u00a0«\u00a0" + nomQuery + "\u00a0»" : "", villeQuery ? "ville\u00a0«\u00a0" + villeQuery + "\u00a0»" : ""].filter(Boolean).join(", ");
+        const msg = hasFilter ? "Aucun résultat pour " + filterDesc + "." : "Lancez un scrape pour commencer la prospection.";
         tbody.innerHTML = '<tr><td colspan="4"><div class="empty"><strong>Aucun résultat</strong>' + msg + '</div></td></tr>';
       } else {
         data.data.forEach(function(r) {
@@ -1054,8 +1071,10 @@
     }
 
     function exportCsv() {
-      var url = "/api/export";
-      if (exportScope !== "all") url += "?phoneType=" + exportScope;
+      var params = [];
+      if (exportScope !== "all") params.push("phoneType=" + exportScope);
+      if (villeQuery) params.push("ville=" + encodeURIComponent(villeQuery));
+      var url = "/api/export" + (params.length ? "?" + params.join("&") : "");
       window.location = url;
       var labels = { all: "Téléchargement du CSV…", mobile: "Export mobiles…", fixe: "Export fixes…" };
       toast(labels[exportScope] || "Téléchargement du CSV…");

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -700,7 +700,7 @@
         <div class="stat-label">Avec téléphone</div>
         <div class="stat-value" id="statFound">0</div>
       </div>
-      <div class="stat" id="tab-mobile" onclick="toggleMobile()">
+      <div class="stat" id="tab-mobile" onclick="setFilter('mobile')">
         <div class="stat-label">Mobile</div>
         <div class="stat-value" id="statMobile">0</div>
       </div>
@@ -754,7 +754,6 @@
     let pollInterval      = null;
     let retryPollInterval = null;
     let activeFilter      = "all";
-    let phoneTypeFilter   = null;
     let exportScope       = "all";
     let activeScope       = "region";
     let searchTimeout     = null;
@@ -801,10 +800,10 @@
     /* ── Filter ── */
     function setFilter(f) {
       activeFilter = f;
-      ["all","found","notfound","dupes"].forEach(function(id) {
+      ["all","found","mobile","notfound","dupes"].forEach(function(id) {
         document.getElementById("tab-" + id).classList.toggle("active", id === f);
       });
-      const labels = { all: "", found: "Avec téléphone", notfound: "Non trouvés", dupes: "" };
+      const labels = { all: "", found: "Avec téléphone", mobile: "Mobile", notfound: "Non trouvés", dupes: "" };
       document.getElementById("filterLabel").textContent = labels[f] || "";
       document.getElementById("retrySection").style.display = f === "notfound" ? "" : "none";
       fetchResults();
@@ -816,12 +815,6 @@
       var cleaned = phone.replace(/[\s.+()-]/g, "");
       var norm = cleaned.startsWith("33") && cleaned.length === 11 ? "0" + cleaned.slice(2) : cleaned;
       return /^0[67]/.test(norm);
-    }
-
-    function toggleMobile() {
-      phoneTypeFilter = phoneTypeFilter === "mobile" ? null : "mobile";
-      document.getElementById("tab-mobile").classList.toggle("active", phoneTypeFilter === "mobile");
-      fetchResults();
     }
 
     /* ── Search ── */
@@ -869,7 +862,7 @@
       let url = "/api/results?page=1&limit=5000";
       if (activeFilter === "found")    url += "&source=found";
       if (activeFilter === "notfound") url += "&source=non_trouv%C3%A9";
-      if (phoneTypeFilter) url += "&phoneType=" + phoneTypeFilter;
+      if (activeFilter === "mobile")   url += "&phoneType=mobile";
       if (searchQuery) url += "&q=" + encodeURIComponent(searchQuery);
 
       const data = await fetch(url).then(r => r.json());

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -664,7 +664,7 @@
         <div class="stat-value" id="statTotal">0</div>
       </div>
       <div class="stat" id="tab-found" onclick="setFilter('found')">
-        <div class="stat-label">Avec t��léphone</div>
+        <div class="stat-label">Avec téléphone</div>
         <div class="stat-value" id="statFound">0</div>
       </div>
       <div class="stat" id="tab-mobile" onclick="toggleMobile()">

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,7 +59,11 @@ app.get("/api/results", (req, res) => {
     rawSource === "found"      ? "found"      :
     rawSource === "non_trouvé" ? "non_trouvé" : undefined;
   const search = (req.query.q as string | undefined) || undefined;
-  res.json(getPaginated(page, limit, sourceFilter, search));
+  const rawPhoneType = req.query.phoneType as string | undefined;
+  const phoneType =
+    rawPhoneType === "mobile" ? "mobile" :
+    rawPhoneType === "fixe"   ? "fixe"   : undefined;
+  res.json(getPaginated(page, limit, sourceFilter, search, phoneType));
 });
 
 app.post("/api/scrape", (req, res) => {
@@ -157,8 +161,12 @@ app.post("/api/retry-pj", (req, res) => {
   res.json({ message: "Retry Pages Jaunes lancé", total: records.length });
 });
 
-app.get("/api/export", (_req, res) => {
-  const records = getAll();
+app.get("/api/export", (req, res) => {
+  const rawPhoneType = req.query.phoneType as string | undefined;
+  const phoneType =
+    rawPhoneType === "mobile" ? "mobile" :
+    rawPhoneType === "fixe"   ? "fixe"   : undefined;
+  const records = getAll(phoneType);
 
   const header = "siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,source,scraped_at";
   const rows = records.map((r) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import path from "path";
 import express from "express";
-import { initDb, getStats, getAll, getPaginated, getNotFound, updateRecord } from "./dedup";
+import { initDb, getStats, getAll, getPaginated, getNotFound, updateRecord, getFilterOptions, ResultFilters } from "./dedup";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
 import { runPipeline } from "./pipeline";
 import { findPhonePJ, closeBrowser } from "./pagesJaunes";
@@ -43,6 +43,27 @@ let retryPjState: RetryPjState = {
 app.use(express.json());
 app.use(express.static(path.join(__dirname, "public")));
 
+function parseFilters(query: Record<string, unknown>): ResultFilters {
+  const raw = (k: string) => (query[k] as string | undefined) || undefined;
+  const rawSource    = raw("source");
+  const rawPhoneType = raw("phoneType");
+  const rawSourceEx  = raw("sourceExact");
+  return {
+    sourceFilter:
+      rawSource === "found"      ? "found"      :
+      rawSource === "non_trouvé" ? "non_trouvé" : undefined,
+    sourceExact:
+      rawSourceEx === "google"      ? "google"      :
+      rawSourceEx === "pagesjaunes" ? "pagesjaunes"  :
+      rawSourceEx === "non_trouvé"  ? "non_trouvé"  : undefined,
+    nom:         raw("nom"),
+    ville:       raw("ville"),
+    phoneType:   rawPhoneType === "mobile" ? "mobile" : rawPhoneType === "fixe" ? "fixe" : undefined,
+    effectif:    raw("effectif"),
+    departement: raw("departement"),
+  };
+}
+
 app.get("/api/regions", (_req, res) => {
   res.json(Object.keys(REGIONS_DEPARTEMENTS));
 });
@@ -51,20 +72,14 @@ app.get("/api/stats", (_req, res) => {
   res.json(getStats());
 });
 
+app.get("/api/filters", (_req, res) => {
+  res.json(getFilterOptions());
+});
+
 app.get("/api/results", (req, res) => {
-  const page = Math.max(1, Number(req.query.page) || 1);
+  const page  = Math.max(1, Number(req.query.page)  || 1);
   const limit = Math.min(5000, Math.max(1, Number(req.query.limit) || 5000));
-  const rawSource = req.query.source as string | undefined;
-  const sourceFilter =
-    rawSource === "found"      ? "found"      :
-    rawSource === "non_trouvé" ? "non_trouvé" : undefined;
-  const nom   = (req.query.nom  as string | undefined) || undefined;
-  const ville = (req.query.ville as string | undefined) || undefined;
-  const rawPhoneType = req.query.phoneType as string | undefined;
-  const phoneType =
-    rawPhoneType === "mobile" ? "mobile" :
-    rawPhoneType === "fixe"   ? "fixe"   : undefined;
-  res.json(getPaginated(page, limit, sourceFilter, nom, phoneType, ville));
+  res.json(getPaginated(page, limit, parseFilters(req.query as Record<string, unknown>)));
 });
 
 app.post("/api/scrape", (req, res) => {
@@ -163,12 +178,7 @@ app.post("/api/retry-pj", (req, res) => {
 });
 
 app.get("/api/export", (req, res) => {
-  const rawPhoneType = req.query.phoneType as string | undefined;
-  const phoneType =
-    rawPhoneType === "mobile" ? "mobile" :
-    rawPhoneType === "fixe"   ? "fixe"   : undefined;
-  const exportVille = (req.query.ville as string | undefined) || undefined;
-  const records = getAll(phoneType, exportVille);
+  const records = getAll(parseFilters(req.query as Record<string, unknown>));
 
   const header = "siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,source,scraped_at";
   const rows = records.map((r) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,12 +58,13 @@ app.get("/api/results", (req, res) => {
   const sourceFilter =
     rawSource === "found"      ? "found"      :
     rawSource === "non_trouvé" ? "non_trouvé" : undefined;
-  const search = (req.query.q as string | undefined) || undefined;
+  const nom   = (req.query.nom  as string | undefined) || undefined;
+  const ville = (req.query.ville as string | undefined) || undefined;
   const rawPhoneType = req.query.phoneType as string | undefined;
   const phoneType =
     rawPhoneType === "mobile" ? "mobile" :
     rawPhoneType === "fixe"   ? "fixe"   : undefined;
-  res.json(getPaginated(page, limit, sourceFilter, search, phoneType));
+  res.json(getPaginated(page, limit, sourceFilter, nom, phoneType, ville));
 });
 
 app.post("/api/scrape", (req, res) => {
@@ -166,7 +167,8 @@ app.get("/api/export", (req, res) => {
   const phoneType =
     rawPhoneType === "mobile" ? "mobile" :
     rawPhoneType === "fixe"   ? "fixe"   : undefined;
-  const records = getAll(phoneType);
+  const exportVille = (req.query.ville as string | undefined) || undefined;
+  const records = getAll(phoneType, exportVille);
 
   const header = "siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,source,scraped_at";
   const rows = records.map((r) => {


### PR DESCRIPTION
## Résumé

- Classification des numéros de téléphone (mobile 06/07 vs fixe) avec utilitaire dédié, compteur dans les stats et badge visuel dans les tableaux
- Filtres de consultation et d'export par type de téléphone, nom, ville, département, source et tranche d'effectif
- Nouvelle page "Filtres avancés" dans le dashboard avec dropdowns dynamiques peuplés depuis la base de données

## Changements

### Backend
- `src/phoneUtils.ts` (nouveau) — `classifyPhone()` et `phoneTypeCondition()` : classification mobile/fixe par préfixe français (06/07), gestion des formats `0033`, `+33`, `33` et local
- `src/dedup.ts` — interface `ResultFilters` avec 7 critères cumulables, helper `buildWhereClause()`, refactoring de `getPaginated()` et `getAll()`, nouvelle fonction `getFilterOptions()` (valeurs distinctes de la DB)
- `src/server.ts` — helper `parseFilters()` éliminant la duplication, nouvel endpoint `GET /api/filters`, mise à jour de `/api/results` et `/api/export`

### Dashboard
- Onglet **Mobile** dans la stats bar (filtre exclusif, cohérent avec les autres onglets)
- Badge **mobile** / **fixe** affiché à côté de chaque numéro dans les tableaux
- Sélecteur d'export **Tout / Mobile / Fixe** dans la sidebar
- Toolbar : deux champs séparés **Nom** et **Ville** (remplace la recherche unifiée)
- Page **Filtres avancés** (nouvel onglet dans la sidebar) : dropdowns Ville, Département, Source, Effectif, Téléphone + champ Nom, compteur de résultats en temps réel, export CSV respectant tous les filtres actifs

## Test plan

- [ ] `npx tsc --noEmit` passe sans erreur
- [ ] `classifyPhone("0033612345678")` → `"mobile"`, `classifyPhone("01 23 45 67 89")` → `"fixe"`
- [ ] `GET /api/filters` retourne des tableaux de villes, départements, effectifs et sources issus de la DB
- [ ] `GET /api/results?phoneType=mobile` ne retourne que des numéros 06/07
- [ ] `GET /api/export?phoneType=fixe` produit un CSV sans mobile
- [ ] L'onglet Mobile dans le dashboard filtre le tableau et se désactive quand on clique sur un autre onglet
- [ ] La page Filtres avancés se peuple correctement depuis `/api/filters`
- [ ] Le cumul de filtres (ex. ville + source + effectif) fonctionne correctement
- [ ] L'export depuis la page Filtres avancés respecte tous les filtres actifs