### PR TITLE
[Feature] Ajouter la forme juridique dans les données SIRENE (#19)

### DIFF
--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -30,20 +30,22 @@ export interface PaginatedResult<T> {
 }
 
 export interface ResultFilters {
-  sourceFilter?: "found" | "non_trouvé";
-  sourceExact?:  "google" | "non_trouvé";
-  nom?:          string;
-  ville?:        string;
-  phoneType?:    "mobile" | "fixe";
-  effectif?:     string;
-  departement?:  string;
+  sourceFilter?:   "found" | "non_trouvé";
+  sourceExact?:    "google" | "non_trouvé";
+  nom?:            string;
+  ville?:          string;
+  phoneType?:      "mobile" | "fixe";
+  effectif?:       string;
+  departement?:    string;
+  formeJuridique?: string;
 }
 
 export interface FilterOptions {
-  villes:       string[];
-  sources:      string[];
-  effectifs:    Array<{ value: string; label: string }>;
-  departements: string[];
+  villes:           string[];
+  sources:          string[];
+  effectifs:        Array<{ value: string; label: string }>;
+  departements:     string[];
+  formesJuridiques: string[];
 }
 
 const EFFECTIF_LABELS: Record<string, string> = {
@@ -72,7 +74,8 @@ function buildWhereClause(filters: ResultFilters): { where: string; params: unkn
   if (filters.nom?.trim())         { conditions.push("nom LIKE ?");             params.push("%" + filters.nom.trim() + "%"); }
   if (filters.ville?.trim())       { conditions.push("ville LIKE ?");           params.push("%" + filters.ville.trim() + "%"); }
   if (filters.effectif?.trim())    { conditions.push("effectif_tranche = ?");   params.push(filters.effectif.trim()); }
-  if (filters.departement?.trim()) { conditions.push("code_postal LIKE ?");     params.push(filters.departement.trim() + "%"); }
+  if (filters.departement?.trim())    { conditions.push("code_postal LIKE ?");      params.push(filters.departement.trim() + "%"); }
+  if (filters.formeJuridique?.trim()) { conditions.push("forme_juridique = ?");    params.push(filters.formeJuridique.trim()); }
 
   return { where: conditions.length ? "WHERE " + conditions.join(" AND ") : "", params };
 }
@@ -215,5 +218,9 @@ export function getFilterOptions(): FilterOptions {
     .prepare("SELECT DISTINCT SUBSTR(code_postal, 1, 2) as dep FROM scraped WHERE code_postal IS NOT NULL AND code_postal != '' ORDER BY dep")
     .all() as { dep: string }[]).map(r => r.dep);
 
-  return { villes, sources, effectifs, departements };
+  const formesJuridiques = (conn
+    .prepare("SELECT DISTINCT forme_juridique FROM scraped WHERE forme_juridique IS NOT NULL AND forme_juridique != '' ORDER BY forme_juridique")
+    .all() as { forme_juridique: string }[]).map(r => r.forme_juridique);
+
+  return { villes, sources, effectifs, departements, formesJuridiques };
 }

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -107,6 +107,11 @@ export function initDb(): void {
       scraped_at        TEXT
     )
   `);
+  try {
+    db.exec("ALTER TABLE scraped ADD COLUMN forme_juridique TEXT");
+  } catch {
+    // Colonne déjà présente
+  }
 }
 
 export function isKnown(siret: string): boolean {

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -10,6 +10,7 @@ export interface ScrapedRecord {
   codePostal: string;
   telephone: string | null;
   effectifTranche: string;
+  formeJuridique: string;
   source: string;
   scraped_at: string;
 }
@@ -98,6 +99,7 @@ export function initDb(): void {
       code_postal       TEXT,
       telephone         TEXT,
       effectif_tranche  TEXT,
+      forme_juridique   TEXT,
       source            TEXT,
       scraped_at        TEXT
     )
@@ -113,8 +115,8 @@ export function insert(record: ScrapedRecord): void {
   requireDb()
     .prepare(
       `INSERT OR IGNORE INTO scraped
-        (siret, nom, adresse, ville, code_postal, telephone, effectif_tranche, source, scraped_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        (siret, nom, adresse, ville, code_postal, telephone, effectif_tranche, forme_juridique, source, scraped_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       record.siret,
@@ -124,6 +126,7 @@ export function insert(record: ScrapedRecord): void {
       record.codePostal,
       record.telephone,
       record.effectifTranche,
+      record.formeJuridique,
       record.source,
       record.scraped_at,
     );
@@ -147,7 +150,9 @@ export function getStats(): ScrapedStats {
 const SELECT_FIELDS = `
   siret, nom, adresse, ville,
   code_postal as codePostal, telephone,
-  effectif_tranche as effectifTranche, source, scraped_at
+  effectif_tranche as effectifTranche,
+  forme_juridique as formeJuridique,
+  source, scraped_at
 `;
 
 export function getNotFound(): ScrapedRecord[] {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -51,6 +51,7 @@ export async function runPipeline(
         codePostal: etab.codePostal,
         telephone: phone,
         effectifTranche: etab.effectifTranche,
+        formeJuridique: etab.formeJuridique,
         source,
         scraped_at: new Date().toISOString(),
       };

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -35,7 +35,7 @@ export async function runPipeline(
       onProgress?.(++i, etab.nom);
 
       const phone = await findPhoneGoogle(etab.nom, etab.ville);
-      const source = phone !== null ? "google" : "non_trouvé";
+      const scrapeSource = phone !== null ? "google" : "non_trouvé";
 
       if (phone === null) {
         notFoundCount++;
@@ -52,13 +52,13 @@ export async function runPipeline(
         telephone: phone,
         effectifTranche: etab.effectifTranche,
         formeJuridique: etab.formeJuridique,
-        source,
+        source: scrapeSource,
         scraped_at: new Date().toISOString(),
       };
 
       insert(record);
 
-      if (source !== "non_trouvé") {
+      if (scrapeSource !== "non_trouvé") {
         prospects.push(record);
       }
   }

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -826,6 +826,13 @@
         </div>
 
         <div class="filter-field">
+          <label>Forme jur.</label>
+          <select id="fFormeJuridique" onchange="onAdvFilter()">
+            <option value="">Toutes</option>
+          </select>
+        </div>
+
+        <div class="filter-field">
           <label>Téléphone</label>
           <select id="fPhoneType" onchange="onAdvFilter()">
             <option value="">Tous</option>
@@ -854,6 +861,7 @@
             <th>Ville</th>
             <th>CP</th>
             <th>Effectif</th>
+            <th>Forme jur.</th>
             <th title="Cliquer pour copier">Téléphone</th>
             <th>Source</th>
           </tr>
@@ -936,13 +944,15 @@
       var dep    = document.getElementById("fDep").value;
       var src    = document.getElementById("fSource").value;
       var eff    = document.getElementById("fEffectif").value;
+      var fj     = document.getElementById("fFormeJuridique").value;
       var phone  = document.getElementById("fPhoneType").value;
-      if (nom)   params.push("nom="         + encodeURIComponent(nom));
-      if (ville) params.push("ville="       + encodeURIComponent(ville));
-      if (dep)   params.push("departement=" + encodeURIComponent(dep));
-      if (src)   params.push("sourceExact=" + encodeURIComponent(src));
-      if (eff)   params.push("effectif="    + encodeURIComponent(eff));
-      if (phone) params.push("phoneType="   + encodeURIComponent(phone));
+      if (nom)   params.push("nom="            + encodeURIComponent(nom));
+      if (ville) params.push("ville="          + encodeURIComponent(ville));
+      if (dep)   params.push("departement="    + encodeURIComponent(dep));
+      if (src)   params.push("sourceExact="    + encodeURIComponent(src));
+      if (eff)   params.push("effectif="       + encodeURIComponent(eff));
+      if (fj)    params.push("formeJuridique=" + encodeURIComponent(fj));
+      if (phone) params.push("phoneType="      + encodeURIComponent(phone));
       return params;
     }
 
@@ -959,7 +969,7 @@
       tbody.innerHTML = "";
 
       if (!data.data.length) {
-        tbody.innerHTML = '<tr><td colspan="6"><div class="empty"><strong>Aucun résultat</strong>Modifiez les filtres pour afficher des résultats.</div></td></tr>';
+        tbody.innerHTML = '<tr><td colspan="7"><div class="empty"><strong>Aucun résultat</strong>Modifiez les filtres pour afficher des résultats.</div></td></tr>';
         return;
       }
 
@@ -971,6 +981,7 @@
         var tdVille = document.createElement("td"); tdVille.className = "col-ville"; tdVille.textContent = r.ville || "—";
         var tdCp   = document.createElement("td"); tdCp.className   = "col-ville"; tdCp.textContent   = r.codePostal || "—";
         var tdEff  = document.createElement("td"); tdEff.className  = "col-ville"; tdEff.textContent  = EFFECTIF_LABELS[r.effectifTranche] || r.effectifTranche || "—";
+        var tdFj   = document.createElement("td"); tdFj.className   = "col-ville"; tdFj.textContent   = r.formeJuridique || "—";
 
         var phone = r.telephone || "—";
         var tdTel = document.createElement("td"); tdTel.className = "col-tel";
@@ -989,7 +1000,7 @@
         var tdSrc = document.createElement("td"); tdSrc.appendChild(badge);
 
         var tr = document.createElement("tr");
-        tr.append(tdNom, tdVille, tdCp, tdEff, tdTel, tdSrc);
+        tr.append(tdNom, tdVille, tdCp, tdEff, tdFj, tdTel, tdSrc);
         tbody.appendChild(tr);
       });
     }
@@ -1000,7 +1011,7 @@
     }
 
     function resetAdvFilters() {
-      ["fNom","fVille","fDep","fSource","fEffectif","fPhoneType"].forEach(function(id) {
+      ["fNom","fVille","fDep","fSource","fEffectif","fFormeJuridique","fPhoneType"].forEach(function(id) {
         document.getElementById(id).value = "";
       });
       fetchAdvResults();
@@ -1029,6 +1040,11 @@
       var selEff = document.getElementById("fEffectif");
       opts.effectifs.forEach(function(e) {
         var o = document.createElement("option"); o.value = e.value; o.textContent = e.label; selEff.appendChild(o);
+      });
+
+      var selFj = document.getElementById("fFormeJuridique");
+      opts.formesJuridiques.forEach(function(f) {
+        var o = document.createElement("option"); o.value = f; o.textContent = f; selFj.appendChild(o);
       });
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -122,7 +122,7 @@ app.get("/api/status", (_req, res) => {
 app.get("/api/export", (req, res) => {
   const records = getAll(parseFilters(req.query as Record<string, unknown>));
 
-  const header = "siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,source,scraped_at";
+  const header = "siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,forme_juridique,source,scraped_at";
   const rows = records.map((r) => {
     const escape = (v: string | null) => {
       if (!v) return "";
@@ -131,7 +131,7 @@ app.get("/api/export", (req, res) => {
       }
       return v;
     };
-    return [r.siret, r.nom, r.adresse, r.ville, r.codePostal, r.telephone, r.effectifTranche, r.source, r.scraped_at]
+    return [r.siret, r.nom, r.adresse, r.ville, r.codePostal, r.telephone, r.effectifTranche, r.formeJuridique, r.source, r.scraped_at]
       .map(escape)
       .join(",");
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,8 +41,9 @@ function parseFilters(query: Record<string, unknown>): ResultFilters {
     nom:         raw("nom"),
     ville:       raw("ville"),
     phoneType:   rawPhoneType === "mobile" ? "mobile" : rawPhoneType === "fixe" ? "fixe" : undefined,
-    effectif:    raw("effectif"),
-    departement: raw("departement"),
+    effectif:       raw("effectif"),
+    departement:    raw("departement"),
+    formeJuridique: raw("formeJuridique"),
   };
 }
 

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -5,6 +5,14 @@ import "dotenv/config";
 const SIRENE_BASE_URL = "https://api.insee.fr/api-sirene/3.11/siret";
 
 const NAF_CODES = ["10.71C", "10.71D"];
+
+const FORMES_JURIDIQUES: Record<string, string> = {
+  "1000": "EI",
+  "5410": "SARL",
+  "5499": "SARL unipersonnelle",
+  "5710": "SAS",
+  "5720": "SASU",
+};
 // Tranches d'effectif : [11 TO 53] couvre 10+ salariés (11=10-19, 12=20-49, ...)
 const TRANCHE_MIN = "11";
 const TRANCHE_MAX = "53";
@@ -49,6 +57,7 @@ export interface Etablissement {
   codePostal: string;
   effectifTranche: string;
   codeNaf: string;
+  formeJuridique: string;
 }
 
 export interface FetchOptions {
@@ -158,6 +167,7 @@ interface SireneUniteLegale {
   denominationUniteLegale: string | null;
   nomUniteLegale: string | null;
   prenom1UniteLegale: string | null;
+  categorieJuridiqueUniteLegale: string | null;
 }
 
 interface SirenePeriode {
@@ -198,6 +208,9 @@ function mapEtablissement(raw: SireneEtablissement): Etablissement {
     .filter(Boolean)
     .join(" ");
 
+  const codeJuridique = ul.categorieJuridiqueUniteLegale || "";
+  const formeJuridique = FORMES_JURIDIQUES[codeJuridique] ?? codeJuridique;
+
   return {
     siret: raw.siret,
     nom: nom || "Inconnu",
@@ -206,6 +219,7 @@ function mapEtablissement(raw: SireneEtablissement): Etablissement {
     codePostal: adr.codePostalEtablissement || "",
     effectifTranche: raw.trancheEffectifsEtablissement,
     codeNaf: periode?.activitePrincipaleEtablissement || "",
+    formeJuridique,
   };
 }
 

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -13,6 +13,7 @@ const FORMES_JURIDIQUES: Record<string, string> = {
   "5710": "SAS",
   "5720": "SASU",
 };
+
 // Tranches d'effectif : [11 TO 53] couvre 10+ salariés (11=10-19, 12=20-49, ...)
 const TRANCHE_MIN = "11";
 const TRANCHE_MAX = "53";


### PR DESCRIPTION
## Contexte

L'API SIRENE expose `categorieJuridiqueUniteLegale` dans chaque établissement. Ce champ, non extrait jusqu'ici, permet de qualifier les prospects (SARL, SAS, EI…).

## Ce qui a été implémenté

- **`src/sirene.ts`** — dictionnaire `FORMES_JURIDIQUES` (EI, SARL, SARL unipersonnelle, SAS, SASU) avec fallback sur le code brut ; champ `formeJuridique` ajouté dans `Etablissement` et `mapEtablissement()`
- **`src/dedup.ts`** — colonne `forme_juridique` dans la table `scraped` ; migration idempotente `ALTER TABLE ADD COLUMN` pour les bases existantes ; champ propagé dans `ScrapedRecord`, `insert()`, `SELECT_FIELDS` ; filtre `formeJuridique` dans `ResultFilters`, `buildWhereClause()` et `getFilterOptions()`
- **`src/pipeline.ts`** — propagation de `formeJuridique` dans la construction du record
- **`src/server.ts`** — colonne `forme_juridique` dans l'export CSV ; filtre exposé dans `parseFilters()`
- **`src/public/index.html`** — select "Forme jur." dans les filtres avancés, peuplé dynamiquement depuis `/api/filters` ; colonne dans le tableau des résultats

## Critères d'acceptance

- [x] L'interface `Etablissement` possède un champ `formeJuridique: string`
- [x] Mapping des codes courants vers libellés (1000=EI, 5410=SARL, 5499=SARL unipersonnelle, 5710=SAS, 5720=SASU) avec fallback sur le code brut
- [x] Colonne `forme_juridique` ajoutée en base avec migration non-destructive (`ALTER TABLE ADD COLUMN`)
- [x] Export CSV inclut la colonne `forme_juridique`