### PR TITLE
[Feature] Intégrer l'API Annuaire des Entreprises pour récupérer les dirigeants (#20)

### DIFF
--- a/src/annuaireEntreprises.ts
+++ b/src/annuaireEntreprises.ts
@@ -1,0 +1,79 @@
+const BASE_URL = "https://recherche-entreprises.api.gouv.fr/search";
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY = 1000;
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+
+interface Dirigeant {
+  nom: string;
+  prenoms: string;
+  qualite: string;
+}
+
+interface SearchResult {
+  results?: Array<{ dirigeants?: Dirigeant[] }>;
+}
+
+async function fetchWithRetry(url: string): Promise<Response> {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url);
+      if (response.ok || !RETRYABLE_STATUS.has(response.status)) {
+        return response;
+      }
+      if (attempt < MAX_RETRIES - 1) {
+        const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
+        console.warn(
+          `Annuaire Entreprises — HTTP ${response.status}, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`
+        );
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    } catch (err) {
+      if (attempt < MAX_RETRIES - 1) {
+        const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
+        console.warn(
+          `Annuaire Entreprises — erreur réseau, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`
+        );
+        await new Promise((r) => setTimeout(r, delay));
+      } else {
+        throw err;
+      }
+    }
+  }
+  return fetch(url);
+}
+
+function formatDirigeants(dirigeants: Dirigeant[]): string {
+  return dirigeants
+    .map((d) => {
+      const prenoms = d.prenoms ? d.prenoms.trim() : "";
+      const nom = d.nom ? d.nom.trim() : "";
+      const qualite = d.qualite ? d.qualite.trim() : "";
+      const fullName = [prenoms, nom].filter(Boolean).join(" ");
+      return qualite ? `${fullName} (${qualite})` : fullName;
+    })
+    .filter(Boolean)
+    .join(", ");
+}
+
+export async function fetchDirigeants(siren: string): Promise<string | null> {
+  try {
+    const response = await fetchWithRetry(`${BASE_URL}?q=${encodeURIComponent(siren)}`);
+    if (!response.ok) {
+      console.warn(`Annuaire Entreprises — HTTP ${response.status} pour SIREN ${siren}`);
+      return null;
+    }
+
+    const data = (await response.json()) as SearchResult;
+    const dirigeants = data.results?.[0]?.dirigeants;
+    if (!dirigeants || dirigeants.length === 0) return null;
+
+    const formatted = formatDirigeants(dirigeants);
+    return formatted || null;
+  } catch (err) {
+    console.warn(
+      `Annuaire Entreprises — erreur pour SIREN ${siren} :`,
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+}

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -329,26 +329,32 @@ export interface NameDuplicatesReport {
 export function getNameDuplicates(): NameDuplicatesReport {
   const conn = requireDb();
 
+  // Uniquement les noms où au moins une entrée a un téléphone ET au moins une n'en a pas
   const names = (conn
     .prepare(
-      `SELECT nom, COUNT(*) as cnt FROM scraped
+      `SELECT nom,
+              COUNT(*) as cnt,
+              COUNT(CASE WHEN telephone IS NOT NULL AND telephone != '' THEN 1 END) as withPhone,
+              COUNT(CASE WHEN telephone IS NULL OR telephone = '' THEN 1 END) as withoutPhone
+       FROM scraped
        GROUP BY nom
-       HAVING cnt > 1
+       HAVING withPhone > 0 AND withoutPhone > 0
        ORDER BY cnt DESC`
     )
-    .all() as { nom: string; cnt: number }[]);
+    .all() as { nom: string; cnt: number; withPhone: number; withoutPhone: number }[]);
 
-  const groups: NameDuplicateGroup[] = names.map(({ nom, cnt }) => {
+  const groups: NameDuplicateGroup[] = names.map(({ nom, withoutPhone }) => {
     const records = conn
       .prepare(
         `SELECT ${SELECT_FIELDS} FROM scraped WHERE nom = ?
          ORDER BY CASE WHEN telephone IS NOT NULL AND telephone != '' THEN 0 ELSE 1 END ASC, scraped_at DESC`
       )
       .all(nom) as ScrapedRecord[];
-    return { nom, count: cnt, records };
+    return { nom, count: records.length, records };
   });
 
-  const totalToDelete = groups.reduce((sum, g) => sum + g.count - 1, 0);
+  // Seules les entrées sans téléphone sont candidates à la suppression
+  const totalToDelete = groups.reduce((sum, g) => sum + g.records.filter(r => !r.telephone).length, 0);
 
   return { groups, totalDuplicateGroups: groups.length, totalToDelete };
 }
@@ -356,34 +362,17 @@ export function getNameDuplicates(): NameDuplicatesReport {
 export function cleanNameDuplicates(): number {
   const conn = requireDb();
 
-  const names = (conn
+  // Supprimer uniquement les entrées sans téléphone quand une entrée avec le même nom ET un téléphone existe
+  const result = conn
     .prepare(
-      `SELECT nom FROM scraped
-       GROUP BY nom
-       HAVING COUNT(*) > 1`
+      `DELETE FROM scraped
+       WHERE (telephone IS NULL OR telephone = '')
+         AND nom IN (
+           SELECT nom FROM scraped
+           WHERE telephone IS NOT NULL AND telephone != ''
+         )`
     )
-    .all() as { nom: string }[]);
+    .run();
 
-  let deleted = 0;
-
-  const deleteStmt = conn.prepare("DELETE FROM scraped WHERE siret = ?");
-
-  const cleanAll = conn.transaction(() => {
-    for (const { nom } of names) {
-      const rows = conn
-        .prepare(
-          `SELECT siret FROM scraped WHERE nom = ?
-           ORDER BY CASE WHEN telephone IS NOT NULL AND telephone != '' THEN 0 ELSE 1 END ASC, scraped_at DESC`
-        )
-        .all(nom) as { siret: string }[];
-      // garder le premier (a un téléphone > plus récent), supprimer le reste
-      for (let i = 1; i < rows.length; i++) {
-        deleteStmt.run(rows[i].siret);
-        deleted++;
-      }
-    }
-  });
-
-  cleanAll();
-  return deleted;
+  return result.changes;
 }

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -401,3 +401,10 @@ export function cleanNameDuplicates(): number {
 
   return toExclude.length;
 }
+
+export function getExcludedCount(): number {
+  const row = requireDb()
+    .prepare("SELECT COUNT(*) as cnt FROM excluded")
+    .get() as { cnt: number };
+  return row.cnt;
+}

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -265,7 +265,10 @@ export function getPhoneDuplicates(): PhoneDuplicatesReport {
 
   const groups: PhoneDuplicateGroup[] = phones.map(({ telephone, cnt }) => {
     const records = conn
-      .prepare(`SELECT ${SELECT_FIELDS} FROM scraped WHERE telephone = ? ORDER BY scraped_at DESC`)
+      .prepare(
+        `SELECT ${SELECT_FIELDS} FROM scraped WHERE telephone = ?
+         ORDER BY CASE WHEN source != 'non_trouvé' THEN 0 ELSE 1 END ASC, scraped_at DESC`
+      )
       .all(telephone) as ScrapedRecord[];
     return { telephone, count: cnt, records };
   });
@@ -294,9 +297,86 @@ export function cleanPhoneDuplicates(): number {
   const cleanAll = conn.transaction(() => {
     for (const { telephone } of phones) {
       const rows = conn
-        .prepare("SELECT siret FROM scraped WHERE telephone = ? ORDER BY scraped_at DESC")
+        .prepare(
+          `SELECT siret FROM scraped WHERE telephone = ?
+           ORDER BY CASE WHEN source != 'non_trouvé' THEN 0 ELSE 1 END ASC, scraped_at DESC`
+        )
         .all(telephone) as { siret: string }[];
-      // garder le plus récent (rows[0]), supprimer le reste
+      // garder le premier (source confirmée > plus récent), supprimer le reste
+      for (let i = 1; i < rows.length; i++) {
+        deleteStmt.run(rows[i].siret);
+        deleted++;
+      }
+    }
+  });
+
+  cleanAll();
+  return deleted;
+}
+
+export interface NameDuplicateGroup {
+  nom: string;
+  count: number;
+  records: ScrapedRecord[];
+}
+
+export interface NameDuplicatesReport {
+  groups: NameDuplicateGroup[];
+  totalDuplicateGroups: number;
+  totalToDelete: number;
+}
+
+export function getNameDuplicates(): NameDuplicatesReport {
+  const conn = requireDb();
+
+  const names = (conn
+    .prepare(
+      `SELECT nom, COUNT(*) as cnt FROM scraped
+       GROUP BY nom
+       HAVING cnt > 1
+       ORDER BY cnt DESC`
+    )
+    .all() as { nom: string; cnt: number }[]);
+
+  const groups: NameDuplicateGroup[] = names.map(({ nom, cnt }) => {
+    const records = conn
+      .prepare(
+        `SELECT ${SELECT_FIELDS} FROM scraped WHERE nom = ?
+         ORDER BY CASE WHEN telephone IS NOT NULL AND telephone != '' THEN 0 ELSE 1 END ASC, scraped_at DESC`
+      )
+      .all(nom) as ScrapedRecord[];
+    return { nom, count: cnt, records };
+  });
+
+  const totalToDelete = groups.reduce((sum, g) => sum + g.count - 1, 0);
+
+  return { groups, totalDuplicateGroups: groups.length, totalToDelete };
+}
+
+export function cleanNameDuplicates(): number {
+  const conn = requireDb();
+
+  const names = (conn
+    .prepare(
+      `SELECT nom FROM scraped
+       GROUP BY nom
+       HAVING COUNT(*) > 1`
+    )
+    .all() as { nom: string }[]);
+
+  let deleted = 0;
+
+  const deleteStmt = conn.prepare("DELETE FROM scraped WHERE siret = ?");
+
+  const cleanAll = conn.transaction(() => {
+    for (const { nom } of names) {
+      const rows = conn
+        .prepare(
+          `SELECT siret FROM scraped WHERE nom = ?
+           ORDER BY CASE WHEN telephone IS NOT NULL AND telephone != '' THEN 0 ELSE 1 END ASC, scraped_at DESC`
+        )
+        .all(nom) as { siret: string }[];
+      // garder le premier (a un téléphone > plus récent), supprimer le reste
       for (let i = 1; i < rows.length; i++) {
         deleteStmt.run(rows[i].siret);
         deleted++;

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -118,11 +118,20 @@ export function initDb(): void {
   } catch {
     // Colonne déjà présente
   }
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS excluded (
+      siret       TEXT PRIMARY KEY,
+      excluded_at TEXT
+    )
+  `);
 }
 
 export function isKnown(siret: string): boolean {
-  const row = requireDb().prepare("SELECT 1 FROM scraped WHERE siret = ?").get(siret);
-  return row !== undefined;
+  const conn = requireDb();
+  return (
+    conn.prepare("SELECT 1 FROM scraped WHERE siret = ?").get(siret) !== undefined ||
+    conn.prepare("SELECT 1 FROM excluded WHERE siret = ?").get(siret) !== undefined
+  );
 }
 
 export function insert(record: ScrapedRecord): void {
@@ -292,7 +301,9 @@ export function cleanPhoneDuplicates(): number {
 
   let deleted = 0;
 
-  const deleteStmt = conn.prepare("DELETE FROM scraped WHERE siret = ?");
+  const now = new Date().toISOString();
+  const archiveStmt = conn.prepare("INSERT OR IGNORE INTO excluded (siret, excluded_at) VALUES (?, ?)");
+  const deleteStmt  = conn.prepare("DELETE FROM scraped WHERE siret = ?");
 
   const cleanAll = conn.transaction(() => {
     for (const { telephone } of phones) {
@@ -302,8 +313,9 @@ export function cleanPhoneDuplicates(): number {
            ORDER BY CASE WHEN source != 'non_trouvé' THEN 0 ELSE 1 END ASC, scraped_at DESC`
         )
         .all(telephone) as { siret: string }[];
-      // garder le premier (source confirmée > plus récent), supprimer le reste
+      // garder le premier (source confirmée > plus récent), archiver + supprimer le reste
       for (let i = 1; i < rows.length; i++) {
+        archiveStmt.run(rows[i].siret, now);
         deleteStmt.run(rows[i].siret);
         deleted++;
       }
@@ -362,17 +374,30 @@ export function getNameDuplicates(): NameDuplicatesReport {
 export function cleanNameDuplicates(): number {
   const conn = requireDb();
 
-  // Supprimer uniquement les entrées sans téléphone quand une entrée avec le même nom ET un téléphone existe
-  const result = conn
+  // Entrées sans téléphone dont le nom existe aussi avec un téléphone
+  const toExclude = conn
     .prepare(
-      `DELETE FROM scraped
+      `SELECT siret FROM scraped
        WHERE (telephone IS NULL OR telephone = '')
          AND nom IN (
            SELECT nom FROM scraped
            WHERE telephone IS NOT NULL AND telephone != ''
          )`
     )
-    .run();
+    .all() as { siret: string }[];
 
-  return result.changes;
+  if (toExclude.length === 0) return 0;
+
+  const now = new Date().toISOString();
+  const archiveStmt = conn.prepare("INSERT OR IGNORE INTO excluded (siret, excluded_at) VALUES (?, ?)");
+  const deleteStmt  = conn.prepare("DELETE FROM scraped WHERE siret = ?");
+
+  conn.transaction(() => {
+    for (const { siret } of toExclude) {
+      archiveStmt.run(siret, now);
+      deleteStmt.run(siret);
+    }
+  })();
+
+  return toExclude.length;
 }

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -11,6 +11,7 @@ export interface ScrapedRecord {
   telephone: string | null;
   effectifTranche: string;
   formeJuridique: string;
+  dirigeants: string | null;
   source: string;
   scraped_at: string;
 }
@@ -112,6 +113,11 @@ export function initDb(): void {
   } catch {
     // Colonne déjà présente
   }
+  try {
+    db.exec("ALTER TABLE scraped ADD COLUMN dirigeants TEXT");
+  } catch {
+    // Colonne déjà présente
+  }
 }
 
 export function isKnown(siret: string): boolean {
@@ -123,8 +129,8 @@ export function insert(record: ScrapedRecord): void {
   requireDb()
     .prepare(
       `INSERT OR IGNORE INTO scraped
-        (siret, nom, adresse, ville, code_postal, telephone, effectif_tranche, forme_juridique, source, scraped_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        (siret, nom, adresse, ville, code_postal, telephone, effectif_tranche, forme_juridique, dirigeants, source, scraped_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       record.siret,
@@ -135,6 +141,7 @@ export function insert(record: ScrapedRecord): void {
       record.telephone,
       record.effectifTranche,
       record.formeJuridique,
+      record.dirigeants,
       record.source,
       record.scraped_at,
     );
@@ -160,6 +167,7 @@ const SELECT_FIELDS = `
   code_postal as codePostal, telephone,
   effectif_tranche as effectifTranche,
   forme_juridique as formeJuridique,
+  dirigeants,
   source, scraped_at
 `;
 

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -237,3 +237,73 @@ export function getFilterOptions(): FilterOptions {
 
   return { villes, sources, effectifs, departements, formesJuridiques };
 }
+
+export interface PhoneDuplicateGroup {
+  telephone: string;
+  count: number;
+  records: ScrapedRecord[];
+}
+
+export interface PhoneDuplicatesReport {
+  groups: PhoneDuplicateGroup[];
+  totalDuplicateGroups: number;
+  totalToDelete: number;
+}
+
+export function getPhoneDuplicates(): PhoneDuplicatesReport {
+  const conn = requireDb();
+
+  const phones = (conn
+    .prepare(
+      `SELECT telephone, COUNT(*) as cnt FROM scraped
+       WHERE telephone IS NOT NULL AND telephone != ''
+       GROUP BY telephone
+       HAVING cnt > 1
+       ORDER BY cnt DESC`
+    )
+    .all() as { telephone: string; cnt: number }[]);
+
+  const groups: PhoneDuplicateGroup[] = phones.map(({ telephone, cnt }) => {
+    const records = conn
+      .prepare(`SELECT ${SELECT_FIELDS} FROM scraped WHERE telephone = ? ORDER BY scraped_at DESC`)
+      .all(telephone) as ScrapedRecord[];
+    return { telephone, count: cnt, records };
+  });
+
+  const totalToDelete = groups.reduce((sum, g) => sum + g.count - 1, 0);
+
+  return { groups, totalDuplicateGroups: groups.length, totalToDelete };
+}
+
+export function cleanPhoneDuplicates(): number {
+  const conn = requireDb();
+
+  const phones = (conn
+    .prepare(
+      `SELECT telephone FROM scraped
+       WHERE telephone IS NOT NULL AND telephone != ''
+       GROUP BY telephone
+       HAVING COUNT(*) > 1`
+    )
+    .all() as { telephone: string }[]);
+
+  let deleted = 0;
+
+  const deleteStmt = conn.prepare("DELETE FROM scraped WHERE siret = ?");
+
+  const cleanAll = conn.transaction(() => {
+    for (const { telephone } of phones) {
+      const rows = conn
+        .prepare("SELECT siret FROM scraped WHERE telephone = ? ORDER BY scraped_at DESC")
+        .all(telephone) as { siret: string }[];
+      // garder le plus récent (rows[0]), supprimer le reste
+      for (let i = 1; i < rows.length; i++) {
+        deleteStmt.run(rows[i].siret);
+        deleted++;
+      }
+    }
+  });
+
+  cleanAll();
+  return deleted;
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,6 +1,7 @@
 import { Etablissement } from "./sirene";
 import { initDb, isKnown, insert, ScrapedRecord } from "./dedup";
 import { findPhoneGoogle } from "./googleMaps";
+import { fetchDirigeants } from "./annuaireEntreprises";
 
 export interface PipelineResult {
   newCount: number;
@@ -35,6 +36,9 @@ export async function runPipeline(
       onProgress?.(++i, etab.nom);
 
       const phone = await findPhoneGoogle(etab.nom, etab.ville);
+      const siren = etab.siret.substring(0, 9);
+      const dirigeants = await fetchDirigeants(siren);
+      await new Promise((r) => setTimeout(r, 200));
       const scrapeSource = phone !== null ? "google" : "non_trouvé";
 
       if (phone === null) {
@@ -52,6 +56,7 @@ export async function runPipeline(
         telephone: phone,
         effectifTranche: etab.effectifTranche,
         formeJuridique: etab.formeJuridique,
+        dirigeants,
         source: scrapeSource,
         scraped_at: new Date().toISOString(),
       };

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -877,6 +877,12 @@
   <!-- Vue Doublons -->
   <div class="view" id="view-duplicates">
 
+    <!-- Bandeau archivés -->
+    <div style="display:flex;align-items:center;gap:0.6rem;padding:0.55rem 1.2rem;background:var(--bg-elevated);border-bottom:1px solid var(--border);font-size:0.67rem;color:var(--muted)">
+      <span>SIRET archivés (ne seront pas re-scrapés) :</span>
+      <strong id="excludedCount" style="color:var(--text)">—</strong>
+    </div>
+
     <!-- Section : doublons par numéro -->
     <div class="filter-bar" style="align-items:flex-start;gap:1rem;border-bottom:1px solid var(--border);margin-bottom:0">
       <div style="flex:1">
@@ -885,17 +891,17 @@
       </div>
       <div style="display:flex;gap:0.5rem;flex-shrink:0">
         <button class="btn-export" onclick="fetchPhoneDuplicates()">⟳ &nbsp;Analyser</button>
-        <button class="btn-export" id="btnCleanPhone" style="background:var(--accent);color:#fff;display:none" onclick="cleanPhoneDups()">✕ &nbsp;Nettoyer</button>
+        <button class="btn-export" id="btnCleanPhone" style="background:var(--accent);color:#fff;display:none" onclick="cleanPhoneDups()">✕ &nbsp;Archiver les doublons</button>
       </div>
     </div>
 
-    <div class="table-area" style="max-height:38vh">
+    <div class="table-area" style="max-height:35vh">
       <table>
         <thead>
           <tr>
             <th>Numéro</th>
             <th>×</th>
-            <th>Établissements (le 1er est conservé)</th>
+            <th>Établissements — <span style="color:var(--success)">conservé</span> / <span style="color:var(--muted)">archivé</span></th>
           </tr>
         </thead>
         <tbody id="dupPhoneBody"></tbody>
@@ -905,22 +911,22 @@
     <!-- Section : doublons par nom -->
     <div class="filter-bar" style="align-items:flex-start;gap:1rem;border-top:1px solid var(--border);margin-top:0">
       <div style="flex:1">
-        <div style="font-size:0.62rem;letter-spacing:0.12em;text-transform:uppercase;color:var(--muted);margin-bottom:0.3rem">Même nom d'entreprise</div>
+        <div style="font-size:0.62rem;letter-spacing:0.12em;text-transform:uppercase;color:var(--muted);margin-bottom:0.3rem">Même nom d'entreprise (sans téléphone, avec doublon qui en a un)</div>
         <div class="filter-count" id="dupNameSummary">Cliquez sur Analyser.</div>
       </div>
       <div style="display:flex;gap:0.5rem;flex-shrink:0">
         <button class="btn-export" onclick="fetchNameDuplicates()">⟳ &nbsp;Analyser</button>
-        <button class="btn-export" id="btnCleanName" style="background:var(--accent);color:#fff;display:none" onclick="cleanNameDups()">✕ &nbsp;Nettoyer</button>
+        <button class="btn-export" id="btnCleanName" style="background:var(--accent);color:#fff;display:none" onclick="cleanNameDups()">✕ &nbsp;Archiver les sans tél.</button>
       </div>
     </div>
 
-    <div class="table-area" style="max-height:38vh">
+    <div class="table-area" style="max-height:35vh">
       <table>
         <thead>
           <tr>
             <th>Nom</th>
             <th>×</th>
-            <th>Entrées (le 1er avec tél. est conservé)</th>
+            <th>Entrées — <span style="color:var(--success)">avec tél. = conservé</span> / <span style="color:var(--muted)">sans tél. = archivé</span></th>
           </tr>
         </thead>
         <tbody id="dupNameBody"></tbody>
@@ -993,22 +999,45 @@
       document.getElementById("navFilters").classList.toggle("active", view === "filters");
       document.getElementById("navDuplicates").classList.toggle("active", view === "duplicates");
       if (view === "filters") fetchAdvResults();
-      if (view === "duplicates") { fetchPhoneDuplicates(); fetchNameDuplicates(); }
+      if (view === "duplicates") { fetchExcludedCount(); fetchPhoneDuplicates(); fetchNameDuplicates(); }
     }
 
     /* ── Doublons helpers ── */
-    function renderDupGroups(groups, tbody, keyField, labelFn) {
+    function fetchExcludedCount() {
+      fetch("/api/duplicates/excluded-count")
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          document.getElementById("excludedCount").textContent = data.count;
+        });
+    }
+
+    function renderDupGroups(groups, tbody, keyField, isKeptFn) {
       tbody.innerHTML = "";
       groups.forEach(function(g) {
-        var label = g.records.map(function(r) {
-          var tel = r.telephone ? " [" + r.telephone + "]" : " [sans tél.]";
-          return r.nom + " (" + (r.ville || "?") + ")" + tel;
-        }).join(" | ");
         var tr = document.createElement("tr");
-        var tdKey  = document.createElement("td"); tdKey.className = "col-tel"; tdKey.textContent = g[keyField]; tdKey.title = g[keyField];
-        var tdCount = document.createElement("td"); tdCount.textContent = "×" + g.count;
-        var tdLabel = document.createElement("td"); tdLabel.className = "col-nom"; tdLabel.textContent = label; tdLabel.title = label;
-        tr.append(tdKey, tdCount, tdLabel);
+
+        var tdKey = document.createElement("td");
+        tdKey.className = "col-tel";
+        tdKey.textContent = g[keyField];
+        tdKey.title = g[keyField];
+
+        var tdCount = document.createElement("td");
+        tdCount.textContent = "×" + g.count;
+
+        var tdEntries = document.createElement("td");
+        tdEntries.className = "col-nom";
+        g.records.forEach(function(r, idx) {
+          var kept = isKeptFn(r, idx);
+          var span = document.createElement("span");
+          var tel = r.telephone ? " [" + r.telephone + "]" : " [sans tél.]";
+          span.textContent = r.nom + " (" + (r.ville || "?") + ")" + tel;
+          span.style.color = kept ? "var(--success)" : "var(--muted)";
+          span.title = kept ? "Conservé" : "Archivé (ne sera pas re-scrapé)";
+          if (idx > 0) { var sep = document.createTextNode("  |  "); tdEntries.appendChild(sep); }
+          tdEntries.appendChild(span);
+        });
+
+        tr.append(tdKey, tdCount, tdEntries);
         tbody.appendChild(tr);
       });
     }
@@ -1028,23 +1057,25 @@
             tbody.innerHTML = '<tr><td colspan="3"><div class="empty"><strong>Base propre</strong></div></td></tr>';
             return;
           }
-          summary.textContent = data.totalDuplicateGroups + " numéro(s) en double — " + data.totalToDelete + " enregistrement(s) à supprimer (celui avec tél. confirmé conservé)";
+          summary.textContent = data.totalDuplicateGroups + " numéro(s) en double — " + data.totalToDelete + " à archiver (SIRET mémorisé, non re-scrapé)";
           btnClean.style.display = "";
-          renderDupGroups(data.groups, tbody, "telephone", function(g) { return g.telephone; });
+          // conservé = index 0 (source confirmée > plus récent)
+          renderDupGroups(data.groups, tbody, "telephone", function(_r, idx) { return idx === 0; });
         })
         .catch(function() { toast("Erreur lors de l'analyse des doublons de numéros"); });
     }
 
     function cleanPhoneDups() {
-      if (!confirm("Supprimer les doublons de numéros ? L'entrée avec téléphone confirmé (Google) est conservée, sinon la plus récente.")) return;
+      if (!confirm("Archiver les doublons de numéros ?\n\nL'entrée avec téléphone confirmé (Google) est conservée, sinon la plus récente.\nLes autres sont retirées de la base mais leurs SIRET sont mémorisés : ils ne seront pas re-scrapés.")) return;
       fetch("/api/duplicates/phone/clean", { method: "POST" })
         .then(function(r) { return r.json(); })
         .then(function(data) {
-          toast(data.deleted + " enregistrement(s) supprimé(s)");
+          toast(data.deleted + " enregistrement(s) archivé(s)");
+          fetchExcludedCount();
           fetchPhoneDuplicates();
           fetchStats();
         })
-        .catch(function() { toast("Erreur lors du nettoyage"); });
+        .catch(function() { toast("Erreur lors de l'archivage"); });
     }
 
     /* ── Doublons par nom ── */
@@ -1057,24 +1088,26 @@
           var tbody = document.getElementById("dupNameBody");
 
           if (data.totalDuplicateGroups === 0) {
-            summary.textContent = "Aucun doublon de nom d'entreprise détecté.";
+            summary.textContent = "Aucun doublon de nom détecté (avec et sans tél.).";
             btnClean.style.display = "none";
             tbody.innerHTML = '<tr><td colspan="3"><div class="empty"><strong>Base propre</strong></div></td></tr>';
             return;
           }
-          summary.textContent = data.totalDuplicateGroups + " nom(s) en double — " + data.totalToDelete + " enregistrement(s) à supprimer (celui avec tél. conservé)";
+          summary.textContent = data.totalDuplicateGroups + " nom(s) concerné(s) — " + data.totalToDelete + " entrée(s) sans tél. à archiver (celles avec tél. différents sont conservées)";
           btnClean.style.display = "";
-          renderDupGroups(data.groups, tbody, "nom", function(g) { return g.nom; });
+          // conservé = a un téléphone (index 0 dans l'ordre trié)
+          renderDupGroups(data.groups, tbody, "nom", function(r) { return !!(r.telephone); });
         })
         .catch(function() { toast("Erreur lors de l'analyse des doublons de noms"); });
     }
 
     function cleanNameDups() {
-      if (!confirm("Supprimer les doublons de noms ? L'entrée avec un téléphone est conservée, sinon la plus récente.")) return;
+      if (!confirm("Archiver les entrées sans téléphone ?\n\nSeules les entrées SANS numéro sont archivées, uniquement si le même nom existe avec un téléphone.\nLes entrées avec des numéros différents ne sont pas touchées.\nLes SIRET archivés ne seront pas re-scrapés.")) return;
       fetch("/api/duplicates/name/clean", { method: "POST" })
         .then(function(r) { return r.json(); })
         .then(function(data) {
-          toast(data.deleted + " enregistrement(s) supprimé(s)");
+          toast(data.deleted + " enregistrement(s) archivé(s)");
+          fetchExcludedCount();
           fetchNameDuplicates();
           fetchStats();
         })

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -552,6 +552,107 @@
     .toast.warn    { border-color: rgba(245,158,11,0.3); color: var(--warn); }
     .toast.error   { border-color: rgba(239,68,68,0.3); color: #f87171; }
 
+    /* ── MODAL ── */
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.65);
+      z-index: 200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.18s;
+    }
+    .modal-overlay.open { opacity: 1; pointer-events: all; }
+
+    .modal {
+      background: var(--bg-card);
+      border: 1px solid var(--border-hover);
+      border-radius: 8px;
+      width: min(860px, 92vw);
+      max-height: 80vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      transform: translateY(12px);
+      transition: transform 0.18s;
+    }
+    .modal-overlay.open .modal { transform: translateY(0); }
+
+    .modal-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.85rem 1.1rem;
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .modal-title {
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      color: var(--text);
+    }
+    .modal-subtitle {
+      font-size: 0.62rem;
+      color: var(--muted);
+      margin-top: 0.15rem;
+    }
+    .modal-close {
+      background: none;
+      border: none;
+      color: var(--muted);
+      font-size: 1rem;
+      cursor: pointer;
+      line-height: 1;
+      padding: 0.2rem 0.4rem;
+      border-radius: 4px;
+      transition: color 0.15s, background 0.15s;
+    }
+    .modal-close:hover { color: var(--text); background: var(--bg-elevated); }
+
+    .modal-body {
+      overflow-y: auto;
+      flex: 1;
+    }
+    .modal-body table { width: 100%; border-collapse: collapse; }
+    .modal-body thead th {
+      position: sticky;
+      top: 0;
+      background: var(--bg-card);
+      padding: 0.55rem 0.9rem;
+      font-size: 0.6rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--muted);
+      text-align: left;
+      border-bottom: 1px solid var(--border);
+    }
+    .modal-body tbody td {
+      padding: 0.55rem 0.9rem;
+      font-size: 0.72rem;
+      border-bottom: 1px solid var(--border);
+      vertical-align: middle;
+    }
+    .modal-body tbody tr:last-child td { border-bottom: none; }
+
+    .dup-badge {
+      display: inline-block;
+      padding: 0.15rem 0.45rem;
+      border-radius: 4px;
+      font-size: 0.6rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+    .dup-badge.kept     { background: var(--success-dim); color: var(--success); }
+    .dup-badge.archived { background: var(--bg-elevated);  color: var(--muted); }
+
+    tr.dup-row { cursor: pointer; }
+    tr.dup-row:hover td { background: var(--bg-elevated); }
+
     /* ── NAVIGATION VUES ── */
     .nav-tabs {
       display: flex;
@@ -937,6 +1038,35 @@
 
   </main>
 
+  <!-- Modal doublons -->
+  <div class="modal-overlay" id="dupModal" onclick="closeDupModal(event)">
+    <div class="modal">
+      <div class="modal-header">
+        <div>
+          <div class="modal-title" id="modalTitle">Détail du groupe</div>
+          <div class="modal-subtitle" id="modalSubtitle"></div>
+        </div>
+        <button class="modal-close" onclick="closeDupModal()">✕</button>
+      </div>
+      <div class="modal-body">
+        <table>
+          <thead>
+            <tr>
+              <th>Statut</th>
+              <th>Nom</th>
+              <th>Ville</th>
+              <th>SIRET</th>
+              <th>Téléphone</th>
+              <th>Source</th>
+              <th>Scrappé le</th>
+            </tr>
+          </thead>
+          <tbody id="modalBody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
   <!-- Toast container -->
   <div class="toast-container" id="toastContainer"></div>
 
@@ -1015,6 +1145,7 @@
       tbody.innerHTML = "";
       groups.forEach(function(g) {
         var tr = document.createElement("tr");
+        tr.className = "dup-row";
 
         var tdKey = document.createElement("td");
         tdKey.className = "col-tel";
@@ -1032,14 +1163,61 @@
           var tel = r.telephone ? " [" + r.telephone + "]" : " [sans tél.]";
           span.textContent = r.nom + " (" + (r.ville || "?") + ")" + tel;
           span.style.color = kept ? "var(--success)" : "var(--muted)";
-          span.title = kept ? "Conservé" : "Archivé (ne sera pas re-scrapé)";
           if (idx > 0) { var sep = document.createTextNode("  |  "); tdEntries.appendChild(sep); }
           tdEntries.appendChild(span);
         });
 
+        var hint = document.createElement("span");
+        hint.style.cssText = "margin-left:0.6rem;font-size:0.6rem;color:var(--dim)";
+        hint.textContent = "↗ détail";
+        tdEntries.appendChild(hint);
+
         tr.append(tdKey, tdCount, tdEntries);
+        tr.addEventListener("click", function() { openDupModal(g, keyField, isKeptFn); });
         tbody.appendChild(tr);
       });
+    }
+
+    /* ── Modal ── */
+    function openDupModal(group, keyField, isKeptFn) {
+      var keyVal = group[keyField];
+      document.getElementById("modalTitle").textContent = keyField === "telephone"
+        ? "Numéro : " + keyVal
+        : keyVal;
+      document.getElementById("modalSubtitle").textContent =
+        group.count + " enregistrement(s) — cliquer en dehors pour fermer";
+
+      var tbody = document.getElementById("modalBody");
+      tbody.innerHTML = "";
+
+      group.records.forEach(function(r, idx) {
+        var kept = isKeptFn(r, idx);
+        var tr = document.createElement("tr");
+
+        var tdStatus = document.createElement("td");
+        var badge = document.createElement("span");
+        badge.className = "dup-badge " + (kept ? "kept" : "archived");
+        badge.textContent = kept ? "conservé" : "archivé";
+        tdStatus.appendChild(badge);
+
+        var tdNom    = document.createElement("td"); tdNom.textContent = r.nom;
+        var tdVille  = document.createElement("td"); tdVille.textContent = r.ville || "—";
+        var tdSiret  = document.createElement("td"); tdSiret.style.fontFamily = "var(--mono)"; tdSiret.textContent = r.siret;
+        var tdTel    = document.createElement("td"); tdTel.textContent = r.telephone || "—";
+        var tdSource = document.createElement("td"); tdSource.textContent = r.source;
+        var tdDate   = document.createElement("td"); tdDate.textContent = r.scraped_at ? r.scraped_at.slice(0, 10) : "—";
+
+        tr.style.opacity = kept ? "1" : "0.5";
+        tr.append(tdStatus, tdNom, tdVille, tdSiret, tdTel, tdSource, tdDate);
+        tbody.appendChild(tr);
+      });
+
+      document.getElementById("dupModal").classList.add("open");
+    }
+
+    function closeDupModal(e) {
+      if (e && e.target !== document.getElementById("dupModal")) return;
+      document.getElementById("dupModal").classList.remove("open");
     }
 
     /* ── Doublons par numéro ── */

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -877,26 +877,53 @@
   <!-- Vue Doublons -->
   <div class="view" id="view-duplicates">
 
-    <div class="filter-bar" style="align-items:flex-start;gap:1rem;">
+    <!-- Section : doublons par numéro -->
+    <div class="filter-bar" style="align-items:flex-start;gap:1rem;border-bottom:1px solid var(--border);margin-bottom:0">
       <div style="flex:1">
-        <div class="filter-count" id="dupSummary">Cliquez sur Analyser pour détecter les doublons de numéros.</div>
+        <div style="font-size:0.62rem;letter-spacing:0.12em;text-transform:uppercase;color:var(--muted);margin-bottom:0.3rem">Même numéro de téléphone</div>
+        <div class="filter-count" id="dupPhoneSummary">Cliquez sur Analyser.</div>
       </div>
       <div style="display:flex;gap:0.5rem;flex-shrink:0">
-        <button class="btn-export" onclick="fetchDuplicates()">⟳ &nbsp;Analyser</button>
-        <button class="btn-export" id="btnClean" style="background:var(--accent);color:#fff;display:none" onclick="cleanDuplicates()">✕ &nbsp;Nettoyer</button>
+        <button class="btn-export" onclick="fetchPhoneDuplicates()">⟳ &nbsp;Analyser</button>
+        <button class="btn-export" id="btnCleanPhone" style="background:var(--accent);color:#fff;display:none" onclick="cleanPhoneDups()">✕ &nbsp;Nettoyer</button>
       </div>
     </div>
 
-    <div class="table-area">
+    <div class="table-area" style="max-height:38vh">
       <table>
         <thead>
           <tr>
             <th>Numéro</th>
-            <th>Doublons</th>
-            <th>Établissements concernés</th>
+            <th>×</th>
+            <th>Établissements (le 1er est conservé)</th>
           </tr>
         </thead>
-        <tbody id="dupBody"></tbody>
+        <tbody id="dupPhoneBody"></tbody>
+      </table>
+    </div>
+
+    <!-- Section : doublons par nom -->
+    <div class="filter-bar" style="align-items:flex-start;gap:1rem;border-top:1px solid var(--border);margin-top:0">
+      <div style="flex:1">
+        <div style="font-size:0.62rem;letter-spacing:0.12em;text-transform:uppercase;color:var(--muted);margin-bottom:0.3rem">Même nom d'entreprise</div>
+        <div class="filter-count" id="dupNameSummary">Cliquez sur Analyser.</div>
+      </div>
+      <div style="display:flex;gap:0.5rem;flex-shrink:0">
+        <button class="btn-export" onclick="fetchNameDuplicates()">⟳ &nbsp;Analyser</button>
+        <button class="btn-export" id="btnCleanName" style="background:var(--accent);color:#fff;display:none" onclick="cleanNameDups()">✕ &nbsp;Nettoyer</button>
+      </div>
+    </div>
+
+    <div class="table-area" style="max-height:38vh">
+      <table>
+        <thead>
+          <tr>
+            <th>Nom</th>
+            <th>×</th>
+            <th>Entrées (le 1er avec tél. est conservé)</th>
+          </tr>
+        </thead>
+        <tbody id="dupNameBody"></tbody>
       </table>
     </div>
 
@@ -966,53 +993,89 @@
       document.getElementById("navFilters").classList.toggle("active", view === "filters");
       document.getElementById("navDuplicates").classList.toggle("active", view === "duplicates");
       if (view === "filters") fetchAdvResults();
-      if (view === "duplicates") fetchDuplicates();
+      if (view === "duplicates") { fetchPhoneDuplicates(); fetchNameDuplicates(); }
     }
 
-    /* ── Doublons ── */
-    function fetchDuplicates() {
+    /* ── Doublons helpers ── */
+    function renderDupGroups(groups, tbody, keyField, labelFn) {
+      tbody.innerHTML = "";
+      groups.forEach(function(g) {
+        var label = g.records.map(function(r) {
+          var tel = r.telephone ? " [" + r.telephone + "]" : " [sans tél.]";
+          return r.nom + " (" + (r.ville || "?") + ")" + tel;
+        }).join(" | ");
+        var tr = document.createElement("tr");
+        var tdKey  = document.createElement("td"); tdKey.className = "col-tel"; tdKey.textContent = g[keyField]; tdKey.title = g[keyField];
+        var tdCount = document.createElement("td"); tdCount.textContent = "×" + g.count;
+        var tdLabel = document.createElement("td"); tdLabel.className = "col-nom"; tdLabel.textContent = label; tdLabel.title = label;
+        tr.append(tdKey, tdCount, tdLabel);
+        tbody.appendChild(tr);
+      });
+    }
+
+    /* ── Doublons par numéro ── */
+    function fetchPhoneDuplicates() {
       fetch("/api/duplicates/phone")
         .then(function(r) { return r.json(); })
         .then(function(data) {
-          var summary = document.getElementById("dupSummary");
-          var btnClean = document.getElementById("btnClean");
-          var tbody = document.getElementById("dupBody");
+          var summary = document.getElementById("dupPhoneSummary");
+          var btnClean = document.getElementById("btnCleanPhone");
+          var tbody = document.getElementById("dupPhoneBody");
 
           if (data.totalDuplicateGroups === 0) {
             summary.textContent = "Aucun doublon de numéro détecté.";
             btnClean.style.display = "none";
-            tbody.innerHTML = '<tr><td colspan="3"><div class="empty"><strong>Base propre</strong>Aucun numéro en double.</div></td></tr>';
+            tbody.innerHTML = '<tr><td colspan="3"><div class="empty"><strong>Base propre</strong></div></td></tr>';
             return;
           }
-
-          summary.textContent = data.totalDuplicateGroups + " numéro(s) en double — " + data.totalToDelete + " enregistrement(s) à supprimer (le plus récent est conservé)";
+          summary.textContent = data.totalDuplicateGroups + " numéro(s) en double — " + data.totalToDelete + " enregistrement(s) à supprimer (celui avec tél. confirmé conservé)";
           btnClean.style.display = "";
-
-          tbody.innerHTML = "";
-          data.groups.forEach(function(g) {
-            var names = g.records.map(function(r) { return r.nom + " (" + (r.ville || "?") + ")"; }).join(", ");
-            var tr = document.createElement("tr");
-            var tdPhone = document.createElement("td"); tdPhone.className = "col-tel";
-            var sp = document.createElement("span"); sp.textContent = g.telephone; tdPhone.appendChild(sp);
-            tdPhone.title = "Cliquer pour copier";
-            tdPhone.style.cursor = "pointer";
-            tdPhone.addEventListener("click", function() { copyPhone(tdPhone, g.telephone); });
-            var tdCount = document.createElement("td"); tdCount.textContent = "×" + g.count;
-            var tdNames = document.createElement("td"); tdNames.className = "col-nom"; tdNames.textContent = names; tdNames.title = names;
-            tr.append(tdPhone, tdCount, tdNames);
-            tbody.appendChild(tr);
-          });
+          renderDupGroups(data.groups, tbody, "telephone", function(g) { return g.telephone; });
         })
-        .catch(function() { toast("Erreur lors de l'analyse des doublons"); });
+        .catch(function() { toast("Erreur lors de l'analyse des doublons de numéros"); });
     }
 
-    function cleanDuplicates() {
-      if (!confirm("Supprimer les doublons ? Le plus récent sera conservé pour chaque numéro.")) return;
+    function cleanPhoneDups() {
+      if (!confirm("Supprimer les doublons de numéros ? L'entrée avec téléphone confirmé (Google) est conservée, sinon la plus récente.")) return;
       fetch("/api/duplicates/phone/clean", { method: "POST" })
         .then(function(r) { return r.json(); })
         .then(function(data) {
           toast(data.deleted + " enregistrement(s) supprimé(s)");
-          fetchDuplicates();
+          fetchPhoneDuplicates();
+          fetchStats();
+        })
+        .catch(function() { toast("Erreur lors du nettoyage"); });
+    }
+
+    /* ── Doublons par nom ── */
+    function fetchNameDuplicates() {
+      fetch("/api/duplicates/name")
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          var summary = document.getElementById("dupNameSummary");
+          var btnClean = document.getElementById("btnCleanName");
+          var tbody = document.getElementById("dupNameBody");
+
+          if (data.totalDuplicateGroups === 0) {
+            summary.textContent = "Aucun doublon de nom d'entreprise détecté.";
+            btnClean.style.display = "none";
+            tbody.innerHTML = '<tr><td colspan="3"><div class="empty"><strong>Base propre</strong></div></td></tr>';
+            return;
+          }
+          summary.textContent = data.totalDuplicateGroups + " nom(s) en double — " + data.totalToDelete + " enregistrement(s) à supprimer (celui avec tél. conservé)";
+          btnClean.style.display = "";
+          renderDupGroups(data.groups, tbody, "nom", function(g) { return g.nom; });
+        })
+        .catch(function() { toast("Erreur lors de l'analyse des doublons de noms"); });
+    }
+
+    function cleanNameDups() {
+      if (!confirm("Supprimer les doublons de noms ? L'entrée avec un téléphone est conservée, sinon la plus récente.")) return;
+      fetch("/api/duplicates/name/clean", { method: "POST" })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          toast(data.deleted + " enregistrement(s) supprimé(s)");
+          fetchNameDuplicates();
           fetchStats();
         })
         .catch(function() { toast("Erreur lors du nettoyage"); });

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -862,6 +862,7 @@
             <th>CP</th>
             <th>Effectif</th>
             <th>Forme jur.</th>
+            <th>Dirigeants</th>
             <th title="Cliquer pour copier">Téléphone</th>
             <th>Source</th>
           </tr>
@@ -969,7 +970,7 @@
       tbody.innerHTML = "";
 
       if (!data.data.length) {
-        tbody.innerHTML = '<tr><td colspan="7"><div class="empty"><strong>Aucun résultat</strong>Modifiez les filtres pour afficher des résultats.</div></td></tr>';
+        tbody.innerHTML = '<tr><td colspan="8"><div class="empty"><strong>Aucun résultat</strong>Modifiez les filtres pour afficher des résultats.</div></td></tr>';
         return;
       }
 
@@ -982,6 +983,7 @@
         var tdCp   = document.createElement("td"); tdCp.className   = "col-ville"; tdCp.textContent   = r.codePostal || "—";
         var tdEff  = document.createElement("td"); tdEff.className  = "col-ville"; tdEff.textContent  = EFFECTIF_LABELS[r.effectifTranche] || r.effectifTranche || "—";
         var tdFj   = document.createElement("td"); tdFj.className   = "col-ville"; tdFj.textContent   = r.formeJuridique || "—";
+        var tdDir  = document.createElement("td"); tdDir.className  = "col-nom";   tdDir.textContent  = r.dirigeants || "—"; tdDir.title = r.dirigeants || "";
 
         var phone = r.telephone || "—";
         var tdTel = document.createElement("td"); tdTel.className = "col-tel";
@@ -1000,7 +1002,7 @@
         var tdSrc = document.createElement("td"); tdSrc.appendChild(badge);
 
         var tr = document.createElement("tr");
-        tr.append(tdNom, tdVille, tdCp, tdEff, tdFj, tdTel, tdSrc);
+        tr.append(tdNom, tdVille, tdCp, tdEff, tdFj, tdDir, tdTel, tdSrc);
         tbody.appendChild(tr);
       });
     }

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -665,8 +665,9 @@
     <!-- Navigation vues -->
     <div class="s-section">
       <div class="nav-tabs">
-        <button class="nav-tab active" id="navResults" onclick="setView('results')">Résultats</button>
-        <button class="nav-tab"        id="navFilters" onclick="setView('filters')">Filtres</button>
+        <button class="nav-tab active" id="navResults"  onclick="setView('results')">Résultats</button>
+        <button class="nav-tab"        id="navFilters"  onclick="setView('filters')">Filtres</button>
+        <button class="nav-tab"        id="navDuplicates" onclick="setView('duplicates')">Doublons</button>
       </div>
     </div>
 
@@ -873,6 +874,34 @@
 
   </div><!-- /view-filters -->
 
+  <!-- Vue Doublons -->
+  <div class="view" id="view-duplicates">
+
+    <div class="filter-bar" style="align-items:flex-start;gap:1rem;">
+      <div style="flex:1">
+        <div class="filter-count" id="dupSummary">Cliquez sur Analyser pour détecter les doublons de numéros.</div>
+      </div>
+      <div style="display:flex;gap:0.5rem;flex-shrink:0">
+        <button class="btn-export" onclick="fetchDuplicates()">⟳ &nbsp;Analyser</button>
+        <button class="btn-export" id="btnClean" style="background:var(--accent);color:#fff;display:none" onclick="cleanDuplicates()">✕ &nbsp;Nettoyer</button>
+      </div>
+    </div>
+
+    <div class="table-area">
+      <table>
+        <thead>
+          <tr>
+            <th>Numéro</th>
+            <th>Doublons</th>
+            <th>Établissements concernés</th>
+          </tr>
+        </thead>
+        <tbody id="dupBody"></tbody>
+      </table>
+    </div>
+
+  </div><!-- /view-duplicates -->
+
   </main>
 
   <!-- Toast container -->
@@ -932,9 +961,61 @@
       activeView = view;
       document.getElementById("view-results").classList.toggle("active", view === "results");
       document.getElementById("view-filters").classList.toggle("active", view === "filters");
+      document.getElementById("view-duplicates").classList.toggle("active", view === "duplicates");
       document.getElementById("navResults").classList.toggle("active", view === "results");
       document.getElementById("navFilters").classList.toggle("active", view === "filters");
+      document.getElementById("navDuplicates").classList.toggle("active", view === "duplicates");
       if (view === "filters") fetchAdvResults();
+      if (view === "duplicates") fetchDuplicates();
+    }
+
+    /* ── Doublons ── */
+    function fetchDuplicates() {
+      fetch("/api/duplicates/phone")
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          var summary = document.getElementById("dupSummary");
+          var btnClean = document.getElementById("btnClean");
+          var tbody = document.getElementById("dupBody");
+
+          if (data.totalDuplicateGroups === 0) {
+            summary.textContent = "Aucun doublon de numéro détecté.";
+            btnClean.style.display = "none";
+            tbody.innerHTML = '<tr><td colspan="3"><div class="empty"><strong>Base propre</strong>Aucun numéro en double.</div></td></tr>';
+            return;
+          }
+
+          summary.textContent = data.totalDuplicateGroups + " numéro(s) en double — " + data.totalToDelete + " enregistrement(s) à supprimer (le plus récent est conservé)";
+          btnClean.style.display = "";
+
+          tbody.innerHTML = "";
+          data.groups.forEach(function(g) {
+            var names = g.records.map(function(r) { return r.nom + " (" + (r.ville || "?") + ")"; }).join(", ");
+            var tr = document.createElement("tr");
+            var tdPhone = document.createElement("td"); tdPhone.className = "col-tel";
+            var sp = document.createElement("span"); sp.textContent = g.telephone; tdPhone.appendChild(sp);
+            tdPhone.title = "Cliquer pour copier";
+            tdPhone.style.cursor = "pointer";
+            tdPhone.addEventListener("click", function() { copyPhone(tdPhone, g.telephone); });
+            var tdCount = document.createElement("td"); tdCount.textContent = "×" + g.count;
+            var tdNames = document.createElement("td"); tdNames.className = "col-nom"; tdNames.textContent = names; tdNames.title = names;
+            tr.append(tdPhone, tdCount, tdNames);
+            tbody.appendChild(tr);
+          });
+        })
+        .catch(function() { toast("Erreur lors de l'analyse des doublons"); });
+    }
+
+    function cleanDuplicates() {
+      if (!confirm("Supprimer les doublons ? Le plus récent sera conservé pour chaque numéro.")) return;
+      fetch("/api/duplicates/phone/clean", { method: "POST" })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          toast(data.deleted + " enregistrement(s) supprimé(s)");
+          fetchDuplicates();
+          fetchStats();
+        })
+        .catch(function() { toast("Erreur lors du nettoyage"); });
     }
 
     /* ── Filtres avancés ── */

--- a/src/server.ts
+++ b/src/server.ts
@@ -123,7 +123,7 @@ app.get("/api/status", (_req, res) => {
 app.get("/api/export", (req, res) => {
   const records = getAll(parseFilters(req.query as Record<string, unknown>));
 
-  const header = "siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,forme_juridique,source,scraped_at";
+  const header = "siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,forme_juridique,dirigeants,source,scraped_at";
   const rows = records.map((r) => {
     const escape = (v: string | null) => {
       if (!v) return "";
@@ -132,7 +132,7 @@ app.get("/api/export", (req, res) => {
       }
       return v;
     };
-    return [r.siret, r.nom, r.adresse, r.ville, r.codePostal, r.telephone, r.effectifTranche, r.formeJuridique, r.source, r.scraped_at]
+    return [r.siret, r.nom, r.adresse, r.ville, r.codePostal, r.telephone, r.effectifTranche, r.formeJuridique, r.dirigeants, r.source, r.scraped_at]
       .map(escape)
       .join(",");
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import path from "path";
 import express from "express";
-import { initDb, getStats, getAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, ResultFilters } from "./dedup";
+import { initDb, getStats, getAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, ResultFilters } from "./dedup";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
 import { runPipeline } from "./pipeline";
 
@@ -125,6 +125,15 @@ app.get("/api/duplicates/phone", (_req, res) => {
 
 app.post("/api/duplicates/phone/clean", (_req, res) => {
   const deleted = cleanPhoneDuplicates();
+  res.json({ deleted });
+});
+
+app.get("/api/duplicates/name", (_req, res) => {
+  res.json(getNameDuplicates());
+});
+
+app.post("/api/duplicates/name/clean", (_req, res) => {
+  const deleted = cleanNameDuplicates();
   res.json({ deleted });
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import path from "path";
 import express from "express";
-import { initDb, getStats, getAll, getPaginated, getFilterOptions, ResultFilters } from "./dedup";
+import { initDb, getStats, getAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, ResultFilters } from "./dedup";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
 import { runPipeline } from "./pipeline";
 
@@ -117,6 +117,15 @@ app.post("/api/scrape", (req, res) => {
 
 app.get("/api/status", (_req, res) => {
   res.json(scrapeState);
+});
+
+app.get("/api/duplicates/phone", (_req, res) => {
+  res.json(getPhoneDuplicates());
+});
+
+app.post("/api/duplicates/phone/clean", (_req, res) => {
+  const deleted = cleanPhoneDuplicates();
+  res.json({ deleted });
 });
 
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import path from "path";
 import express from "express";
-import { initDb, getStats, getAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, ResultFilters } from "./dedup";
+import { initDb, getStats, getAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./dedup";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
 import { runPipeline } from "./pipeline";
 
@@ -135,6 +135,10 @@ app.get("/api/duplicates/name", (_req, res) => {
 app.post("/api/duplicates/name/clean", (_req, res) => {
   const deleted = cleanNameDuplicates();
   res.json({ deleted });
+});
+
+app.get("/api/duplicates/excluded-count", (_req, res) => {
+  res.json({ count: getExcludedCount() });
 });
 
 


### PR DESCRIPTION
## Résumé

- Intégration de l'API Annuaire des Entreprises (sans clé) pour enrichir chaque établissement avec les noms des dirigeants
- Gestion complète des doublons (numéro de téléphone et nom d'entreprise) avec archivage des SIRET pour éviter le re-scraping
- Vue "Doublons" dans le dashboard avec analyse, nettoyage et modal de détail

## Changements

### Nouveaux fichiers
- `src/annuaireEntreprises.ts` — module d'appel à l'API avec retry et formatage des dirigeants

### Fichiers modifiés
- `src/dedup.ts` — colonne `dirigeants` (migration non-destructive), table `excluded` (archivage SIRET), `isKnown` étendu, détection/nettoyage des doublons par numéro et par nom
- `src/pipeline.ts` — appel `fetchDirigeants()` pour chaque établissement (délai 200ms)
- `src/server.ts` — export CSV avec `dirigeants`, endpoints `/api/duplicates/*`
- `src/public/index.html` — colonne "Dirigeants" (vue avancée), onglet "Doublons" complet

### Comportement des doublons
- **Par numéro** : conserve l'entrée avec source confirmée (Google), archive les autres
- **Par nom** : archive uniquement les entrées sans téléphone si le même nom existe avec un téléphone — les entrées ayant des numéros différents ne sont jamais touchées
- Les SIRET archivés sont mémorisés dans `excluded` : `isKnown()` retourne `true`, aucun re-scraping

## Plan de test

- [ ] Lancer un scrape et vérifier que la colonne "Dirigeants" est remplie dans la vue avancée
- [ ] Vérifier que l'export CSV contient la colonne `dirigeants`
- [ ] Relancer le serveur sur une base existante — migration non-destructive (aucune donnée perdue)
- [ ] Onglet "Doublons" → Analyser par numéro → vérifier les groupes et le marquage conservé/archivé
- [ ] Onglet "Doublons" → Analyser par nom → vérifier que seuls les cas "un avec tél, un sans" remontent
- [ ] Cliquer sur un groupe → modal de détail avec SIRET, source, date
- [ ] Archiver les doublons → relancer un scrape → confirmer que les SIRET archivés sont sautés