### PR TITLE
[Chore] Setup Railway + Postgres + domaine + DNS + variables env (#35)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,28 @@
+# ─── Server ─────────────────────────────────────────────
+PORT=3000
+NODE_ENV=development
+
+# ─── Database ───────────────────────────────────────────
+# Postgres Railway (fournie automatiquement par Railway en prod)
+DATABASE_URL=postgresql://user:pass@host:5432/dbname
+
+# ─── Scraping APIs ──────────────────────────────────────
 SIRENE_TOKEN=xxx
 GOOGLE_MAPS_API_KEY=xxx
-PORT=3000
+
+# ─── Auth (Better Auth) ─────────────────────────────────
+# Générer avec : openssl rand -base64 32
+BETTER_AUTH_SECRET=xxx
+BETTER_AUTH_URL=http://localhost:3000
+
+# ─── Google OAuth ───────────────────────────────────────
+GOOGLE_OAUTH_CLIENT_ID=xxx
+GOOGLE_OAUTH_CLIENT_SECRET=xxx
+
+# ─── Polar (billing) ────────────────────────────────────
+POLAR_API_KEY=xxx
+POLAR_WEBHOOK_SECRET=xxx
+
+# ─── Playwright ─────────────────────────────────────────
 # Sur Fedora/Arch : pointer vers chromium système (evite le build Ubuntu de Playwright)
 # PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium

--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,3 @@ GOOGLE_MAPS_API_KEY=xxx
 # ─── À venir (billing Polar) ────────────────────────────
 # POLAR_API_KEY=xxx
 # POLAR_WEBHOOK_SECRET=xxx
-
-# ─── Playwright ─────────────────────────────────────────
-# Sur Fedora/Arch : pointer vers chromium système (evite le build Ubuntu de Playwright)
-# PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium

--- a/.env.example
+++ b/.env.example
@@ -2,26 +2,26 @@
 PORT=3000
 NODE_ENV=development
 
-# ─── Database ───────────────────────────────────────────
-# Postgres Railway (fournie automatiquement par Railway en prod)
-DATABASE_URL=postgresql://user:pass@host:5432/dbname
-
 # ─── Scraping APIs ──────────────────────────────────────
 SIRENE_TOKEN=xxx
 GOOGLE_MAPS_API_KEY=xxx
 
-# ─── Auth (Better Auth) ─────────────────────────────────
+# ─── À venir (#36 — Migration Postgres) ─────────────────
+# Fournie automatiquement par Railway en prod
+# DATABASE_URL=postgresql://user:pass@host:5432/dbname
+
+# ─── À venir (#37 — Auth Better Auth) ───────────────────
 # Générer avec : openssl rand -base64 32
-BETTER_AUTH_SECRET=xxx
-BETTER_AUTH_URL=http://localhost:3000
+# BETTER_AUTH_SECRET=xxx
+# BETTER_AUTH_URL=http://localhost:3000
 
-# ─── Google OAuth ───────────────────────────────────────
-GOOGLE_OAUTH_CLIENT_ID=xxx
-GOOGLE_OAUTH_CLIENT_SECRET=xxx
+# ─── À venir (#37 — Google OAuth) ───────────────────────
+# GOOGLE_OAUTH_CLIENT_ID=xxx
+# GOOGLE_OAUTH_CLIENT_SECRET=xxx
 
-# ─── Polar (billing) ────────────────────────────────────
-POLAR_API_KEY=xxx
-POLAR_WEBHOOK_SECRET=xxx
+# ─── À venir (billing Polar) ────────────────────────────
+# POLAR_API_KEY=xxx
+# POLAR_WEBHOOK_SECRET=xxx
 
 # ─── Playwright ─────────────────────────────────────────
 # Sur Fedora/Arch : pointer vers chromium système (evite le build Ubuntu de Playwright)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Nouvel endpoint `GET /api/health` pour le healthcheck : retourne `200 OK` quand la base de données est accessible, `503 Service Unavailable` sinon ([`a700f73`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/a700f73), [`2221df0`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/2221df0))
+
 ### Changed
 
-- Ajout de la configuration Railway (`railway.json`) avec Nixpacks, healthcheck `/api/health` et restart automatique en cas d'échec ([`5af92b1`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/5af92b1))
+- Configuration Railway ajoutée (`railway.json`) avec Nixpacks, healthcheck `/api/health` et restart automatique en cas d'échec ([`5af92b1`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/5af92b1))
 - Variables d'environnement de production documentées dans `.env.example` par groupe : base de données, auth, OAuth Google, billing Polar (futures variables commentées avec référence au ticket) ([`e9caf2e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e9caf2e))
 - Script `start:prod` ajouté dans `package.json` pour démarrer le serveur compilé en production (`node dist/server.js`) ([`db5cff8`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/db5cff8))
 
 ### Fixed
 
-- Health check `GET /api/health` retourne désormais `503` si la base de données est inaccessible, au lieu de `200` systématiquement ([`2221df0`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/2221df0))
 - Script `build` rendu idempotent : la copie de `src/public/` vers `dist/public/` ne crée plus de sous-dossier parasite lors de builds consécutifs ([`e492309`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e492309))
 
 [Unreleased]: https://github.com/alex-robert-fr/entreprise-scrapper/commits/main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-04-18
+
 ### Added
 
-- Nouvel endpoint `GET /api/health` pour le healthcheck : retourne `200 OK` quand la base de données est accessible, `503 Service Unavailable` sinon ([`a700f73`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/a700f73), [`2221df0`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/2221df0))
+#### Scraping
 
-### Changed
+- Pipeline de collecte SIRENE → Google Maps → Annuaire Entreprises pour les boulangeries-pâtisseries françaises (codes NAF `10.71C` et `10.71D`) filtrées sur 15+ salariés
+- Trois portées de scraping : région, département, France entière
+- Limite configurable de résultats par scrape (1 à 10 000)
+- Retry exponentiel (3 tentatives) sur les appels API externes
 
-- Configuration Railway ajoutée (`railway.json`) avec Nixpacks, healthcheck `/api/health` et restart automatique en cas d'échec ([`5af92b1`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/5af92b1))
-- Variables d'environnement de production documentées dans `.env.example` par groupe : base de données, auth, OAuth Google, billing Polar (futures variables commentées avec référence au ticket) ([`e9caf2e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e9caf2e))
-- Script `start:prod` ajouté dans `package.json` pour démarrer le serveur compilé en production (`node dist/server.js`) ([`db5cff8`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/db5cff8))
+#### Dashboard web (`http://localhost:3000`)
 
-### Fixed
+- Lancement d'un scrape depuis l'UI avec choix région/département/France et limite optionnelle
+- Progression temps réel : pourcentage et nom de l'établissement en cours
+- Résumé post-scrape : nouveaux, déjà connus, non trouvés
+- Tableau paginé des résultats (établissement, ville, téléphone, source)
+- Stats globales : total, avec téléphone, mobiles, non trouvés
+- Filtres : nom, ville, département, effectif, forme juridique, type de téléphone
+- Copie du téléphone au clic
+- Détection et nettoyage des doublons par téléphone ou par nom, avec archivage (empêche le re-scrape)
 
-- Script `build` rendu idempotent : la copie de `src/public/` vers `dist/public/` ne crée plus de sous-dossier parasite lors de builds consécutifs ([`e492309`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e492309))
+#### API REST
 
-[Unreleased]: https://github.com/alex-robert-fr/entreprise-scrapper/commits/main
+- `GET /api/health` — statut applicatif (`200 OK` si DB accessible, `503 Service Unavailable` sinon)
+- `GET /api/regions` — liste des régions SIRENE disponibles
+- `GET /api/stats` — compteurs globaux
+- `GET /api/filters` — valeurs disponibles pour chaque filtre (villes, effectifs, formes juridiques, etc.)
+- `GET /api/results` — résultats paginés avec filtres
+- `POST /api/scrape` — lancement asynchrone d'un scrape
+- `GET /api/status` — état du scrape en cours
+- `GET /api/duplicates/phone` + `POST /api/duplicates/phone/clean` — détection et nettoyage des doublons par téléphone
+- `GET /api/duplicates/name` + `POST /api/duplicates/name/clean` — détection et nettoyage des doublons par nom
+- `GET /api/duplicates/excluded-count` — nombre de SIRET archivés
+- `GET /api/export` — export CSV avec filtres appliqués
+
+#### Export CSV
+
+- Colonnes : `siret, nom, adresse, ville, code_postal, telephone, effectif_tranche, forme_juridique, dirigeants, source, scraped_at`
+- Filtrage par type de téléphone (mobile `06`/`07`, fixe, tout) et propagation des filtres avancés
+
+#### Persistance
+
+- Base SQLite locale (`data/scraper.db`) en mode WAL
+- Déduplication par SIRET : un établissement déjà scrappé n'est jamais re-scrappé
+- Archivage des SIRET nettoyés dans une table `excluded` pour empêcher leur re-collecte
+
+#### Déploiement
+
+- Configuration Railway (`railway.json`) avec Nixpacks, healthcheck `/api/health` et restart automatique (`ON_FAILURE`, 3 tentatives max)
+- Script `start:prod` pour démarrer le serveur compilé en production (`node dist/server.js`)
+- Build idempotent : copie de `src/public/` vers `dist/public/` sans sous-dossier parasite
+- Variables d'environnement documentées par groupe dans `.env.example` (scraping + futures variables `DATABASE_URL`, Better Auth, OAuth Google, billing Polar commentées avec référence au ticket)
+- Guide de déploiement Railway (`DEPLOYMENT.md`) : pré-requis, setup, provisioning Postgres, domaine custom, variables d'env, troubleshooting
+
+[Unreleased]: https://github.com/alex-robert-fr/entreprise-scrapper/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/alex-robert-fr/entreprise-scrapper/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Ajout de la configuration Railway (`railway.json`) avec Nixpacks, healthcheck `/api/health` et restart automatique en cas d'échec ([`5af92b1`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/5af92b1))
+- Variables d'environnement de production documentées dans `.env.example` par groupe : base de données, auth, OAuth Google, billing Polar (futures variables commentées avec référence au ticket) ([`e9caf2e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e9caf2e))
+- Script `start:prod` ajouté dans `package.json` pour démarrer le serveur compilé en production (`node dist/server.js`) ([`db5cff8`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/db5cff8))
+
+### Fixed
+
+- Health check `GET /api/health` retourne désormais `503` si la base de données est inaccessible, au lieu de `200` systématiquement ([`2221df0`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/2221df0))
+- Script `build` rendu idempotent : la copie de `src/public/` vers `dist/public/` ne crée plus de sous-dossier parasite lors de builds consécutifs ([`e492309`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e492309))
+
+[Unreleased]: https://github.com/alex-robert-fr/entreprise-scrapper/commits/main

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,121 @@
+# Deployment — Railway
+
+Guide pas-à-pas pour déployer le scrapper sur Railway avec Postgres managé, domaine custom et HTTPS.
+
+> **Note importante :** à ce stade, le code utilise encore SQLite (`better-sqlite3`). Le Postgres Railway sera provisionné mais **non utilisé** tant que la migration (#36) n'est pas mergée. Le filesystem Railway étant éphémère, la DB SQLite ne persistera pas entre les redémarrages — c'est accepté dans le cadre du ticket #35.
+
+## Pré-requis
+
+- Compte Railway (https://railway.app)
+- Railway CLI : `npm i -g @railway/cli`
+- Accès au repo GitHub `alex-robert-fr/entreprise-scrapper`
+- Domaine acheté chez un registrar (ex : OVH, Gandi, Namecheap)
+
+## 1. Créer le projet Railway
+
+```bash
+railway login
+railway init
+```
+
+- Nom du projet : `entreprise-scrapper-prod`
+- Accepter la création d'un nouveau projet vide
+
+Ou via dashboard : https://railway.app/new → **Empty Project**.
+
+## 2. Lier le repo GitHub
+
+Dans le dashboard Railway :
+
+1. Cliquer sur **New Service** → **GitHub Repo**
+2. Sélectionner `alex-robert-fr/entreprise-scrapper`
+3. Branche : `main`
+4. **Auto-deploy** activé (push sur `main` déclenche un deploy)
+
+## 3. Provisionner Postgres
+
+Dans le dashboard Railway, projet `entreprise-scrapper-prod` :
+
+1. Cliquer sur **New** → **Database** → **PostgreSQL**
+2. Railway provisionne l'instance et crée la variable `DATABASE_URL` automatiquement dans le service
+3. Lier la variable au service web : **Settings** → **Variables** → vérifier que `DATABASE_URL` pointe bien sur `${{Postgres.DATABASE_URL}}`
+
+## 4. Configurer le domaine custom
+
+### Dans Railway
+
+1. Service web → **Settings** → **Networking** → **Custom Domain**
+2. Entrer `leadscraper.<tld>` (TLD à confirmer avec le product owner)
+3. Railway affiche un enregistrement CNAME (ex : `xxx.up.railway.app`)
+
+### Chez le registrar
+
+1. Créer un enregistrement **CNAME** :
+   - **Nom/Host** : `leadscraper` (ou `@` pour l'apex, selon registrar)
+   - **Valeur/Target** : URL fournie par Railway
+   - **TTL** : 3600 (1h)
+2. Attendre la propagation DNS (5 min à 30 min)
+
+### HTTPS (Let's Encrypt)
+
+Railway émet automatiquement le certificat Let's Encrypt une fois le DNS propagé. Vérifier dans **Settings** → **Networking** que le statut HTTPS est **Active**.
+
+## 5. Renseigner les variables d'environnement
+
+Dashboard Railway → service web → **Variables** → ajouter :
+
+| Variable | Valeur | Notes |
+|----------|--------|-------|
+| `NODE_ENV` | `production` | |
+| `PORT` | (laisser Railway l'injecter) | Railway injecte `PORT` automatiquement |
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | référence Railway |
+| `SIRENE_TOKEN` | valeur réelle | |
+| `GOOGLE_MAPS_API_KEY` | valeur réelle | |
+| `BETTER_AUTH_SECRET` | `openssl rand -base64 32` | à générer |
+| `BETTER_AUTH_URL` | `https://leadscraper.<tld>` | URL publique |
+| `GOOGLE_OAUTH_CLIENT_ID` | (vide acceptable pour l'instant) | requis quand #37 merge |
+| `GOOGLE_OAUTH_CLIENT_SECRET` | (vide acceptable) | requis quand #37 merge |
+| `POLAR_API_KEY` | (vide acceptable) | requis quand billing arrive |
+| `POLAR_WEBHOOK_SECRET` | (vide acceptable) | idem |
+
+## 6. Déclencher le premier deploy
+
+```bash
+git push origin main
+```
+
+Ou via dashboard Railway : **Deployments** → **Deploy**.
+
+Vérifier :
+
+- [ ] Build réussi (logs Railway → `npm run build` passe)
+- [ ] Health check OK (`GET /api/health` → 200)
+- [ ] Domaine résout et HTTPS actif
+- [ ] App accessible sur `https://leadscraper.<tld>`
+
+## Troubleshooting
+
+### Build échoue
+
+- Vérifier les logs Railway → onglet **Deployments** → cliquer sur le deploy échoué
+- Souvent lié à une dépendance native (`better-sqlite3` nécessite `node-gyp`) : Nixpacks la gère par défaut
+
+### Health check KO
+
+- Vérifier que `/api/health` répond localement : `curl http://localhost:3000/api/health`
+- Ajuster `healthcheckTimeout` dans `railway.json` si le démarrage est long
+
+### Playwright en prod
+
+Le fallback Pages Jaunes utilise Playwright qui nécessite un Chromium. Nixpacks ne l'installe pas par défaut. Options :
+
+- **Option A** : accepter que le fallback PJ soit KO en prod (dégradé, acceptable)
+- **Option B** : ajouter un `nixpacks.toml` avec `chromium` dans `apt-packages` et `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium`
+
+À trancher dans un ticket ultérieur.
+
+## Références
+
+- Railway docs : https://docs.railway.app
+- Nixpacks : https://nixpacks.com
+- Issue associée : #35

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -105,15 +105,6 @@ Vérifier :
 - Vérifier que `/api/health` répond localement : `curl http://localhost:3000/api/health`
 - Ajuster `healthcheckTimeout` dans `railway.json` si le démarrage est long
 
-### Playwright en prod
-
-Le fallback Pages Jaunes utilise Playwright qui nécessite un Chromium. Nixpacks ne l'installe pas par défaut. Options :
-
-- **Option A** : accepter que le fallback PJ soit KO en prod (dégradé, acceptable)
-- **Option B** : ajouter un `nixpacks.toml` avec `chromium` dans `apt-packages` et `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium`
-
-À trancher dans un ticket ultérieur.
-
 ## Références
 
 - Railway docs : https://docs.railway.app

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -7,8 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Docs
-
-- Guide de déploiement Railway ajouté (`DEPLOYMENT.md`) : pré-requis, setup, provisioning Postgres, domaine custom, variables d'env, troubleshooting ([`e5cf863`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e5cf863))
-
 [Unreleased]: https://github.com/alex-robert-fr/entreprise-scrapper/commits/main

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -1,0 +1,14 @@
+# Technical Changes
+
+All notable technical changes targeted at contributors will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Docs
+
+- Guide de déploiement Railway ajouté (`DEPLOYMENT.md`) : pré-requis, setup, provisioning Postgres, domaine custom, variables d'env, troubleshooting ([`e5cf863`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e5cf863))
+
+[Unreleased]: https://github.com/alex-robert-fr/entreprise-scrapper/commits/main

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "ts-node src/main.ts",
     "server": "ts-node src/server.ts",
     "start:prod": "node dist/server.js",
-    "build": "tsc && cp -r src/public dist/public",
+    "build": "tsc && rm -rf dist/public && cp -r src/public dist/public",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "ts-node src/main.ts",
     "server": "ts-node src/server.ts",
-    "build": "tsc",
+    "start:prod": "node dist/server.js",
+    "build": "tsc && cp -r src/public dist/public",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/railway.json
+++ b/railway.json
@@ -7,7 +7,7 @@
   "deploy": {
     "startCommand": "npm run start:prod",
     "healthcheckPath": "/api/health",
-    "healthcheckTimeout": 30,
+    "healthcheckTimeout": 60,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3
   }

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "npm run build"
+  },
+  "deploy": {
+    "startCommand": "npm run start:prod",
+    "healthcheckPath": "/api/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,6 +47,10 @@ function parseFilters(query: Record<string, unknown>): ResultFilters {
   };
 }
 
+app.get("/api/health", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
 app.get("/api/regions", (_req, res) => {
   res.json(Object.keys(REGIONS_DEPARTEMENTS));
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,7 +48,12 @@ function parseFilters(query: Record<string, unknown>): ResultFilters {
 }
 
 app.get("/api/health", (_req, res) => {
-  res.json({ status: "ok" });
+  try {
+    getStats();
+    res.json({ status: "ok" });
+  } catch {
+    res.status(503).json({ status: "error", reason: "db_unavailable" });
+  }
 });
 
 app.get("/api/regions", (_req, res) => {


### PR DESCRIPTION
## Contexte

Mise en place de l'infrastructure de déploiement Railway pour l'environnement de production (phase J1 — Infra & Foundations).

Closes #35

## Changements côté code

- `railway.json` — configuration Nixpacks : buildCommand `npm run build`, startCommand `npm run start:prod`, healthcheck `/api/health`, restart ON_FAILURE (3 retries max)
- `.env.example` — variables de production documentées par groupe (scraping, auth Better Auth, OAuth Google, billing Polar) ; variables futures commentées avec référence au ticket correspondant
- `package.json` — ajout du script `start:prod` (`node dist/server.js`) et correction du script `build` pour rendre la copie de `src/public/` idempotente
- `src/server.ts` — endpoint `GET /api/health` : retourne `503` si la DB est inaccessible
- `DEPLOYMENT.md` — checklist des actions externes : création projet Railway, provisioning Postgres, configuration domaine + DNS + HTTPS, variables d'env en prod
- `CHANGELOG.md` — inventaire complet de l'app pour la release v0.1.0
- `TECHNICAL_CHANGES.md` — créé (journal technique contributeur)

## Critères d'acceptance

- [x] `.env.example` à jour avec toutes les variables documentées
- [x] Déploiement auto configuré (push `main` → `railway.json` déclenche build + deploy)
- [ ] Projet Railway créé et lié au repo GitHub (action externe — voir `DEPLOYMENT.md`)
- [ ] Postgres provisionné et accessible via `DATABASE_URL` (action externe)
- [ ] Domaine connecté avec HTTPS valide (action externe)
- [ ] Variables d'environnement renseignées en prod (action externe)

> **Note :** Le code utilise encore SQLite (`better-sqlite3`). Le Postgres Railway sera provisionné mais non utilisé jusqu'au merge de #36. Le filesystem Railway étant éphémère, la DB SQLite ne persistera pas entre redémarrages — comportement attendu et documenté.

## Test plan

- [x] `npx tsc --noEmit` — aucune erreur TypeScript
- [x] `npm run build` (x2 consécutifs) — idempotent, `dist/public/` ne contient que `index.html`
- [x] `node dist/server.js` démarre et répond sur `/api/health`
- [ ] Push sur `main` → vérifier que Railway déclenche un build réussi (après setup externe)