### PR TITLE
[Feature] Middleware auth + protection des routes API (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Les filtres par nom et ville du dashboard sont désormais insensibles à la casse (comportement SQLite restauré sous Postgres via `ILIKE`) ([`86aa1b4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/86aa1b4))
 - `GET /api/export` streame désormais le CSV ligne par ligne via un curseur Postgres : plus de timeout HTTP ni de saturation mémoire sur de grands volumes ([`e6909ab`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e6909ab))
 
+### Security
+
+- Routes API protégées par authentification : toutes les routes `/api/*` (sauf `/api/auth/*` et `/api/health`) retournent `401 Unauthorized` si la session est absente ; le dashboard `/` redirige vers `/login` (302) si non authentifié ([`874cd46`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/874cd46))
+- `GET /api/me` désormais protégé par le middleware d'authentification, cohérent avec le reste des routes ([`59f9104`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/59f9104))
+
 ## [0.1.0](https://github.com/alex-robert-fr/entreprise-scrapper/releases/tag/v0.1.0) - 2026-04-18
 
 ### Added

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `server.ts` : wrapper `asyncHandler` + middleware d'erreur global sur toutes les routes async (évite le crash du process sur erreur DB non catchée) ([`e6909ab`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e6909ab))
 - `phoneUtils.ts` : `phoneTypeCondition` renvoie un fragment `SQL` Drizzle typé au lieu d'une string brute ([`8b7a160`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8b7a160))
 - `getFilterOptions` : migration de 4 requêtes raw vers `db.selectDistinct()` typé ([`733402e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/733402e))
+- `src/middleware/auth.ts` : extraction de `makeAuthGuard(onUnauth)` pour mutualiser `requireAuth` et `dashboardGuard` ; type union `UserRole = "user" | "admin"` + helper `toUserRole` pour normaliser le champ `role` Better Auth ; ajout de `requireAdminAuth` (guard atomique session + rôle) pour les futures routes admin ([`2ec076d`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/2ec076d))
 
 ### Docs
 
@@ -35,4 +36,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variable `BETTER_AUTH_TRUSTED_ORIGINS` (CSV) pour configurer plusieurs origines autorisées en plus de `BETTER_AUTH_URL` ([`0f20ef4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/0f20ef4))
 - Hook `user.create.after` : gestion d'erreur avec relance et log d'avertissement si conflit sur insert crédits ([`0f20ef4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/0f20ef4))
 
-[Unreleased]: https://github.com/alex-robert-fr/entreprise-scrapper/commits/main
+[Unreleased]: https://github.com/alex-robert-fr/entreprise-scrapper/compare/v0.1.0...HEAD

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,47 @@
+import type { RequestHandler } from "express";
+import { fromNodeHeaders } from "better-auth/node";
+import { auth } from "../auth";
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  role: string;
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: AuthUser;
+    }
+  }
+}
+
+export const requireAuth: RequestHandler = (req, res, next) => {
+  auth.api
+    .getSession({ headers: fromNodeHeaders(req.headers) })
+    .then((result) => {
+      if (!result) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
+      req.user = {
+        id: result.user.id,
+        email: result.user.email,
+        role: result.user.role ?? "user",
+      };
+      next();
+    })
+    .catch(next);
+};
+
+export const requireAdmin: RequestHandler = (req, res, next) => {
+  if (!req.user) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+  if (req.user.role !== "admin") {
+    res.status(403).json({ error: "Forbidden" });
+    return;
+  }
+  next();
+};

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -2,11 +2,16 @@ import type { RequestHandler } from "express";
 import { fromNodeHeaders } from "better-auth/node";
 import { auth } from "../auth";
 
+export type UserRole = "user" | "admin";
+
 export interface AuthUser {
   id: string;
   email: string;
-  role: string;
+  role: UserRole;
 }
+
+const toUserRole = (raw: string | null | undefined): UserRole =>
+  raw === "admin" ? "admin" : "user";
 
 declare global {
   namespace Express {
@@ -16,23 +21,33 @@ declare global {
   }
 }
 
-export const requireAuth: RequestHandler = (req, res, next) => {
-  auth.api
-    .getSession({ headers: fromNodeHeaders(req.headers) })
-    .then((result) => {
-      if (!result) {
-        res.status(401).json({ error: "Unauthorized" });
-        return;
-      }
-      req.user = {
-        id: result.user.id,
-        email: result.user.email,
-        role: result.user.role ?? "user",
-      };
-      next();
-    })
-    .catch(next);
-};
+export function makeAuthGuard(onUnauth: RequestHandler): RequestHandler {
+  return (req, res, next) => {
+    auth.api
+      .getSession({ headers: fromNodeHeaders(req.headers) })
+      .then((result) => {
+        if (!result) {
+          onUnauth(req, res, next);
+          return;
+        }
+        req.user = {
+          id: result.user.id,
+          email: result.user.email,
+          role: toUserRole(result.user.role),
+        };
+        next();
+      })
+      .catch(next);
+  };
+}
+
+export const requireAuth = makeAuthGuard((_req, res) => {
+  res.status(401).json({ error: "Unauthorized" });
+});
+
+export const dashboardGuard = makeAuthGuard((_req, res) => {
+  res.redirect(302, "/login");
+});
 
 export const requireAdmin: RequestHandler = (req, res, next) => {
   if (!req.user) {
@@ -44,4 +59,27 @@ export const requireAdmin: RequestHandler = (req, res, next) => {
     return;
   }
   next();
+};
+
+export const requireAdminAuth: RequestHandler = (req, res, next) => {
+  auth.api
+    .getSession({ headers: fromNodeHeaders(req.headers) })
+    .then((result) => {
+      if (!result) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
+      const role = toUserRole(result.user.role);
+      if (role !== "admin") {
+        res.status(403).json({ error: "Forbidden" });
+        return;
+      }
+      req.user = {
+        id: result.user.id,
+        email: result.user.email,
+        role,
+      };
+      next();
+    })
+    .catch(next);
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import path from "path";
 import express, { type Request, type Response, type NextFunction, type RequestHandler } from "express";
 import { toNodeHandler, fromNodeHeaders } from "better-auth/node";
 import { auth } from "./auth";
+import { requireAuth } from "./middleware/auth";
 import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
 import { runPipeline } from "./pipeline";
@@ -76,25 +77,25 @@ app.get("/api/health", async (_req, res) => {
   }
 });
 
-app.get("/api/regions", (_req, res) => {
+app.get("/api/regions", requireAuth, (_req, res) => {
   res.json(Object.keys(REGIONS_DEPARTEMENTS));
 });
 
-app.get("/api/stats", asyncHandler(async (_req, res) => {
+app.get("/api/stats", requireAuth, asyncHandler(async (_req, res) => {
   res.json(await getStats());
 }));
 
-app.get("/api/filters", asyncHandler(async (_req, res) => {
+app.get("/api/filters", requireAuth, asyncHandler(async (_req, res) => {
   res.json(await getFilterOptions());
 }));
 
-app.get("/api/results", asyncHandler(async (req, res) => {
+app.get("/api/results", requireAuth, asyncHandler(async (req, res) => {
   const page  = Math.max(1, Number(req.query.page)  || 1);
   const limit = Math.min(5000, Math.max(1, Number(req.query.limit) || 5000));
   res.json(await getPaginated(page, limit, parseFilters(req.query as Record<string, unknown>)));
 }));
 
-app.post("/api/scrape", (req, res) => {
+app.post("/api/scrape", requireAuth, (req, res) => {
   if (scrapeState.status === "running") {
     res.status(409).json({ error: "Scrape déjà en cours" });
     return;
@@ -144,34 +145,34 @@ app.post("/api/scrape", (req, res) => {
   res.json({ message: "Scrape lancé" });
 });
 
-app.get("/api/status", (_req, res) => {
+app.get("/api/status", requireAuth, (_req, res) => {
   res.json(scrapeState);
 });
 
-app.get("/api/duplicates/phone", asyncHandler(async (_req, res) => {
+app.get("/api/duplicates/phone", requireAuth, asyncHandler(async (_req, res) => {
   res.json(await getPhoneDuplicates());
 }));
 
-app.post("/api/duplicates/phone/clean", asyncHandler(async (_req, res) => {
+app.post("/api/duplicates/phone/clean", requireAuth, asyncHandler(async (_req, res) => {
   const deleted = await cleanPhoneDuplicates();
   res.json({ deleted });
 }));
 
-app.get("/api/duplicates/name", asyncHandler(async (_req, res) => {
+app.get("/api/duplicates/name", requireAuth, asyncHandler(async (_req, res) => {
   res.json(await getNameDuplicates());
 }));
 
-app.post("/api/duplicates/name/clean", asyncHandler(async (_req, res) => {
+app.post("/api/duplicates/name/clean", requireAuth, asyncHandler(async (_req, res) => {
   const deleted = await cleanNameDuplicates();
   res.json({ deleted });
 }));
 
-app.get("/api/duplicates/excluded-count", asyncHandler(async (_req, res) => {
+app.get("/api/duplicates/excluded-count", requireAuth, asyncHandler(async (_req, res) => {
   res.json({ count: await getExcludedCount() });
 }));
 
 
-app.get("/api/export", asyncHandler(async (req, res) => {
+app.get("/api/export", requireAuth, asyncHandler(async (req, res) => {
   res.setHeader("Content-Type", "text/csv; charset=utf-8");
   res.setHeader("Content-Disposition", "attachment; filename=export.csv");
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import path from "path";
 import express, { type Request, type Response, type NextFunction, type RequestHandler } from "express";
 import { toNodeHandler, fromNodeHeaders } from "better-auth/node";
 import { auth } from "./auth";
-import { requireAuth } from "./middleware/auth";
+import { requireAuth, dashboardGuard } from "./middleware/auth";
 import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
 import { runPipeline } from "./pipeline";
@@ -37,30 +37,13 @@ app.all("/api/auth/*", toNodeHandler(auth));
 
 app.use(express.json());
 
-const dashboardGuard: RequestHandler = (req, res, next) => {
-  auth.api
-    .getSession({ headers: fromNodeHeaders(req.headers) })
-    .then((result) => {
-      if (!result) {
-        res.redirect(302, "/login");
-        return;
-      }
-      next();
-    })
-    .catch(next);
-};
-
 app.get("/", dashboardGuard);
 app.get("/index.html", dashboardGuard);
 
 app.use(express.static(path.join(__dirname, "public")));
 
-app.get("/api/me", asyncHandler(async (req, res) => {
+app.get("/api/me", requireAuth, asyncHandler(async (req, res) => {
   const result = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) });
-  if (!result) {
-    res.status(401).json({ error: "Non authentifié" });
-    return;
-  }
   res.json(result);
 }));
 
@@ -89,8 +72,9 @@ app.get("/api/health", async (_req, res) => {
   try {
     await getStats();
     res.json({ status: "ok" });
-  } catch {
-    res.status(503).json({ status: "error", reason: "db_unavailable" });
+  } catch (err) {
+    console.error("[health] db unavailable", err);
+    res.status(503).json({ status: "error" });
   }
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,23 @@ let scrapeState: ScrapeState = {
 app.all("/api/auth/*", toNodeHandler(auth));
 
 app.use(express.json());
+
+const dashboardGuard: RequestHandler = (req, res, next) => {
+  auth.api
+    .getSession({ headers: fromNodeHeaders(req.headers) })
+    .then((result) => {
+      if (!result) {
+        res.redirect(302, "/login");
+        return;
+      }
+      next();
+    })
+    .catch(next);
+};
+
+app.get("/", dashboardGuard);
+app.get("/index.html", dashboardGuard);
+
 app.use(express.static(path.join(__dirname, "public")));
 
 app.get("/api/me", asyncHandler(async (req, res) => {


### PR DESCRIPTION
## Contexte

Closes #38

Introduit le middleware d'authentification Better Auth et protège l'ensemble des routes API du dashboard.

## Changements

- `src/middleware/auth.ts` (nouveau) :
  - `makeAuthGuard(onUnauth)` — factory centralisée pour les guards session
  - `requireAuth` — 401 JSON si session absente
  - `dashboardGuard` — redirect 302 vers `/login` si session absente
  - `requireAdmin` — 403 si `req.user.role !== "admin"` (à chaîner après `requireAuth`)
  - `requireAdminAuth` — guard atomique session + rôle pour les futures routes admin
  - Type union `UserRole = "user" | "admin"` + helper `toUserRole` pour normaliser le champ Better Auth
  - Module augmentation `Express.Request.user?: AuthUser` pour typer `req.user` dans tous les handlers

- `src/server.ts` (modifié) :
  - `requireAuth` appliqué sur 12 routes : `GET /api/stats`, `/api/results`, `/api/filters`, `/api/export`, `/api/regions`, `/api/status`, `POST /api/scrape`, `GET/POST /api/duplicates/*`
  - `GET /api/me` protégé par `requireAuth`
  - `GET /` et `GET /index.html` redirigent vers `/login` si non authentifié
  - `/api/auth/*`, `/api/health` restent publics
  - `/api/health` ne divulgue plus le motif d'erreur (`reason` retiré de la réponse 503)

## Note

`/login` redirige actuellement vers une 404 — `public/login.html` sera créé dans une issue ultérieure (pages login/signup). L'infrastructure de garde est en place.

## Test

- Sans cookie : `curl /api/stats` → `401 { "error": "Unauthorized" }`
- Avec session valide : toutes les routes API répondent normalement
- `GET /` sans session → redirect 302 `/login`
- `GET /api/health` et `/api/auth/*` accessibles sans auth