### PR TITLE
[Security] Validation inputs Zod sur toutes les routes (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Routes API protégées par authentification : toutes les routes `/api/*` (sauf `/api/auth/*` et `/api/health`) retournent `401 Unauthorized` si la session est absente ; le dashboard `/` redirige vers `/login` (302) si non authentifié ([`874cd46`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/874cd46))
 - `GET /api/me` désormais protégé par le middleware d'authentification, cohérent avec le reste des routes ([`59f9104`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/59f9104))
+- Les routes `POST /api/scrape`, `GET /api/results` et `GET /api/export` valident désormais tous les inputs : une valeur invalide (région inconnue, département mal formé, limite hors plage, filtre non reconnu) retourne `400` avec le champ fautif et un message explicite, au lieu d'un comportement imprévisible ([`6601e52`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/6601e52))
 
 ## [0.1.0](https://github.com/alex-robert-fr/entreprise-scrapper/releases/tag/v0.1.0) - 2026-04-18
 

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `getFilterOptions` : migration de 4 requêtes raw vers `db.selectDistinct()` typé ([`733402e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/733402e))
 - `src/middleware/auth.ts` : extraction de `makeAuthGuard(onUnauth)` pour mutualiser `requireAuth` et `dashboardGuard` ; type union `UserRole = "user" | "admin"` + helper `toUserRole` pour normaliser le champ `role` Better Auth ; ajout de `requireAdminAuth` (guard atomique session + rôle) pour les futures routes admin ([`2ec076d`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/2ec076d))
 - Pages login/signup déplacées de `src/public/` vers `src/views/` (servies exclusivement via routes Express, non exposées par `express.static`) ; ajout de `alreadyAuthGuard` dans `src/middleware/auth.ts` ; script `build` étendu pour copier `src/views/` vers `dist/views/` ([`43cde21`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/43cde21))
+- Ajout de `src/schemas/` (scrape, filters, billing) : schémas Zod centralisés pour tous les inputs HTTP ; middlewares `validateBody`/`validateQuery` qui stockent les données validées dans `res.locals.query` ; `normalizeRegion` exportée depuis `sirene.ts` ([`eba11cb`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/eba11cb))
 
 ### Docs
 
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Retire `better-sqlite3` et `@types/better-sqlite3` ; ajoute `drizzle-orm` + `postgres` (runtime) et `drizzle-kit` (dev) ([`fe0569b`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/fe0569b))
 - Ajout `better-auth@1.6.5` ; bump `drizzle-orm` 0.36 → 0.45 et `drizzle-kit` 0.28 → 0.31 pour compatibilité ([`8847f64`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8847f64))
+- Ajout de `zod@4.3.6` ([`1c0e0ee`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/1c0e0ee))
 
 ### Chore
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "express": "^4",
         "minimist": "^1",
         "ora": "^5",
-        "postgres": "^3"
+        "postgres": "^3",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/express": "^4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "express": "^4",
     "minimist": "^1",
     "ora": "^5",
-    "postgres": "^3"
+    "postgres": "^3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/express": "^4",

--- a/src/db/scraped.ts
+++ b/src/db/scraped.ts
@@ -2,6 +2,19 @@ import { and, desc, eq, ilike, inArray, like, sql, type SQL } from "drizzle-orm"
 import { db, pgClient } from "./client";
 import { scrapedRecords, excluded } from "./schema";
 import { phoneTypeCondition } from "../phoneUtils";
+// Les filtres consommes par la couche DB — formes miroir du schema Zod
+// cote HTTP, mais avec "sourceFilter" comme nom interne (le param HTTP
+// s'appelle "source").
+export interface ResultFilters {
+  sourceFilter?:   "found" | "non_trouvé";
+  sourceExact?:    "google" | "non_trouvé";
+  nom?:            string;
+  ville?:          string;
+  phoneType?:      "mobile" | "fixe";
+  effectif?:       string;
+  departement?:    string;
+  formeJuridique?: string;
+}
 
 export interface ScrapedRecord {
   siret: string;
@@ -31,16 +44,6 @@ export interface PaginatedResult<T> {
   totalPages: number;
 }
 
-export interface ResultFilters {
-  sourceFilter?:   "found" | "non_trouvé";
-  sourceExact?:    "google" | "non_trouvé";
-  nom?:            string;
-  ville?:          string;
-  phoneType?:      "mobile" | "fixe";
-  effectif?:       string;
-  departement?:    string;
-  formeJuridique?: string;
-}
 
 export interface FilterOptions {
   villes:           string[];

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -1,0 +1,44 @@
+import type { RequestHandler } from "express";
+import type { ZodTypeAny, z } from "zod";
+
+interface ValidationIssue {
+  path: string;
+  message: string;
+}
+
+function formatIssues(error: z.ZodError): ValidationIssue[] {
+  return error.issues.map((issue) => ({
+    path: issue.path.join(".") || "(root)",
+    message: issue.message,
+  }));
+}
+
+export function validateBody<S extends ZodTypeAny>(schema: S): RequestHandler {
+  return (req, res, next) => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      res.status(400).json({
+        error: "Validation failed",
+        issues: formatIssues(result.error),
+      });
+      return;
+    }
+    req.body = result.data;
+    next();
+  };
+}
+
+export function validateQuery<S extends ZodTypeAny>(schema: S): RequestHandler {
+  return (req, res, next) => {
+    const result = schema.safeParse(req.query);
+    if (!result.success) {
+      res.status(400).json({
+        error: "Validation failed",
+        issues: formatIssues(result.error),
+      });
+      return;
+    }
+    req.query = result.data as typeof req.query;
+    next();
+  };
+}

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -28,6 +28,8 @@ export function validateBody<S extends ZodTypeAny>(schema: S): RequestHandler {
   };
 }
 
+export const VALIDATED_QUERY_KEY = "query" as const;
+
 export function validateQuery<S extends ZodTypeAny>(schema: S): RequestHandler {
   return (req, res, next) => {
     const result = schema.safeParse(req.query);
@@ -38,7 +40,11 @@ export function validateQuery<S extends ZodTypeAny>(schema: S): RequestHandler {
       });
       return;
     }
-    req.query = result.data as typeof req.query;
+    res.locals[VALIDATED_QUERY_KEY] = result.data;
     next();
   };
+}
+
+export function getValidatedQuery<T>(res: { locals: Record<string, unknown> }): T {
+  return res.locals[VALIDATED_QUERY_KEY] as T;
 }

--- a/src/schemas/billing.schema.ts
+++ b/src/schemas/billing.schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+// Schema preparatoire pour les webhooks Polar — la route consommatrice
+// n'est pas encore branchee dans le serveur. Affiner les champs
+// "data" quand l'integration sera implementee.
+export const polarWebhookSchema = z
+  .object({
+    type: z.string().min(1),
+    data: z
+      .object({
+        id: z.string().optional(),
+        customer_id: z.string().optional(),
+        product_id: z.string().optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export type PolarWebhook = z.infer<typeof polarWebhookSchema>;

--- a/src/schemas/billing.schema.ts
+++ b/src/schemas/billing.schema.ts
@@ -14,6 +14,6 @@ export const polarWebhookSchema = z
       })
       .passthrough(),
   })
-  .passthrough();
+  .strict();
 
 export type PolarWebhook = z.infer<typeof polarWebhookSchema>;

--- a/src/schemas/filters.schema.ts
+++ b/src/schemas/filters.schema.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const resultFiltersSchema = z
+  .object({
+    sourceFilter: z.enum(["found", "non_trouvé"]).optional(),
+    sourceExact: z.enum(["google", "non_trouvé"]).optional(),
+    nom: z.string().trim().min(1).optional(),
+    ville: z.string().trim().min(1).optional(),
+    phoneType: z.enum(["mobile", "fixe"]).optional(),
+    effectif: z.string().trim().min(1).optional(),
+    departement: z
+      .string()
+      .trim()
+      .regex(/^\d{2,3}$|^2[AB]$/, "Format departement invalide")
+      .optional(),
+    formeJuridique: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
+export const resultsQuerySchema = resultFiltersSchema.extend({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(5000).default(5000),
+});
+
+export const exportQuerySchema = resultFiltersSchema;
+
+export type ResultFiltersInput = z.infer<typeof resultFiltersSchema>;
+export type ResultsQuery = z.infer<typeof resultsQuerySchema>;
+export type ExportQuery = z.infer<typeof exportQuerySchema>;

--- a/src/schemas/filters.schema.ts
+++ b/src/schemas/filters.schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const resultFiltersSchema = z
   .object({
-    sourceFilter: z.enum(["found", "non_trouvé"]).optional(),
+    source: z.enum(["found", "non_trouvé"]).optional(),
     sourceExact: z.enum(["google", "non_trouvé"]).optional(),
     nom: z.string().trim().min(1).optional(),
     ville: z.string().trim().min(1).optional(),

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,0 +1,10 @@
+export { scrapeBodySchema, type ScrapeBody } from "./scrape.schema";
+export {
+  resultFiltersSchema,
+  resultsQuerySchema,
+  exportQuerySchema,
+  type ResultFiltersInput,
+  type ResultsQuery,
+  type ExportQuery,
+} from "./filters.schema";
+export { polarWebhookSchema, type PolarWebhook } from "./billing.schema";

--- a/src/schemas/scrape.schema.ts
+++ b/src/schemas/scrape.schema.ts
@@ -20,19 +20,19 @@ const departementSchema = z
     message: "Departement inconnu",
   });
 
-const nafCodeSchema = z
-  .string()
-  .regex(/^\d{4}[A-Z]$/, "Format code NAF invalide (ex: 1071C)");
-
 export const scrapeBodySchema = z
   .object({
     region: regionSchema.optional(),
     departement: departementSchema.optional(),
     all: z.boolean().optional(),
     limit: z.number().int().min(1).max(10000).optional(),
-    professionId: z.string().trim().min(1).optional(),
-    nafCodes: z.array(nafCodeSchema).min(1).optional(),
   })
-  .strict();
+  .strict()
+  .refine(
+    (body) =>
+      [body.region !== undefined, body.departement !== undefined, body.all === true]
+        .filter(Boolean).length <= 1,
+    { message: "region, departement et all sont mutuellement exclusifs" },
+  );
 
 export type ScrapeBody = z.infer<typeof scrapeBodySchema>;

--- a/src/schemas/scrape.schema.ts
+++ b/src/schemas/scrape.schema.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { REGIONS_DEPARTEMENTS, normalizeRegion } from "../sirene";
+
+const VALID_REGION_KEYS = new Set(Object.keys(REGIONS_DEPARTEMENTS));
+const VALID_DEPARTEMENTS = new Set(Object.values(REGIONS_DEPARTEMENTS).flat());
+
+const regionSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((value) => VALID_REGION_KEYS.has(normalizeRegion(value)), {
+    message: `Region inconnue. Valeurs autorisees : ${Object.keys(REGIONS_DEPARTEMENTS).join(", ")}`,
+  });
+
+const departementSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{2,3}$|^2[AB]$/, "Format departement invalide (ex: 75, 971, 2A)")
+  .refine((value) => VALID_DEPARTEMENTS.has(value.padStart(2, "0")) || VALID_DEPARTEMENTS.has(value), {
+    message: "Departement inconnu",
+  });
+
+const nafCodeSchema = z
+  .string()
+  .regex(/^\d{4}[A-Z]$/, "Format code NAF invalide (ex: 1071C)");
+
+export const scrapeBodySchema = z
+  .object({
+    region: regionSchema.optional(),
+    departement: departementSchema.optional(),
+    all: z.boolean().optional(),
+    limit: z.number().int().min(1).max(10000).optional(),
+    professionId: z.string().trim().min(1).optional(),
+    nafCodes: z.array(nafCodeSchema).min(1).optional(),
+  })
+  .strict();
+
+export type ScrapeBody = z.infer<typeof scrapeBodySchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,9 +4,18 @@ import express, { type Request, type Response, type NextFunction, type RequestHa
 import { toNodeHandler, fromNodeHeaders } from "better-auth/node";
 import { auth } from "./auth";
 import { requireAuth, dashboardGuard, alreadyAuthGuard } from "./middleware/auth";
+import { validateBody, validateQuery } from "./middleware/validate";
 import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
 import { runPipeline } from "./pipeline";
+import {
+  scrapeBodySchema,
+  resultsQuerySchema,
+  exportQuerySchema,
+  type ScrapeBody,
+  type ResultsQuery,
+  type ExportQuery,
+} from "./schemas";
 
 const asyncHandler =
   (fn: (req: Request, res: Response) => Promise<unknown>): RequestHandler =>
@@ -54,24 +63,16 @@ app.get("/api/me", requireAuth, asyncHandler(async (req, res) => {
   res.json(result);
 }));
 
-function parseFilters(query: Record<string, unknown>): ResultFilters {
-  const raw = (k: string) => (query[k] as string | undefined) || undefined;
-  const rawSource    = raw("source");
-  const rawPhoneType = raw("phoneType");
-  const rawSourceEx  = raw("sourceExact");
+function pickFilters(query: ResultsQuery | ExportQuery): ResultFilters {
   return {
-    sourceFilter:
-      rawSource === "found"      ? "found"      :
-      rawSource === "non_trouvé" ? "non_trouvé" : undefined,
-    sourceExact:
-      rawSourceEx === "google"     ? "google"     :
-      rawSourceEx === "non_trouvé" ? "non_trouvé" : undefined,
-    nom:         raw("nom"),
-    ville:       raw("ville"),
-    phoneType:   rawPhoneType === "mobile" ? "mobile" : rawPhoneType === "fixe" ? "fixe" : undefined,
-    effectif:       raw("effectif"),
-    departement:    raw("departement"),
-    formeJuridique: raw("formeJuridique"),
+    sourceFilter:   query.source,
+    sourceExact:    query.sourceExact,
+    nom:            query.nom,
+    ville:          query.ville,
+    phoneType:      query.phoneType,
+    effectif:       query.effectif,
+    departement:    query.departement,
+    formeJuridique: query.formeJuridique,
   };
 }
 
@@ -97,27 +98,18 @@ app.get("/api/filters", requireAuth, asyncHandler(async (_req, res) => {
   res.json(await getFilterOptions());
 }));
 
-app.get("/api/results", requireAuth, asyncHandler(async (req, res) => {
-  const page  = Math.max(1, Number(req.query.page)  || 1);
-  const limit = Math.min(5000, Math.max(1, Number(req.query.limit) || 5000));
-  res.json(await getPaginated(page, limit, parseFilters(req.query as Record<string, unknown>)));
+app.get("/api/results", requireAuth, validateQuery(resultsQuerySchema), asyncHandler(async (req, res) => {
+  const query = req.query as unknown as ResultsQuery;
+  res.json(await getPaginated(query.page, query.limit, pickFilters(query)));
 }));
 
-app.post("/api/scrape", requireAuth, (req, res) => {
+app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), (req, res) => {
   if (scrapeState.status === "running") {
     res.status(409).json({ error: "Scrape déjà en cours" });
     return;
   }
 
-  const { region, departement, all, limit: rawLimit } = req.body as {
-    region?: string;
-    departement?: string;
-    all?: boolean;
-    limit?: number;
-  };
-  const limit = typeof rawLimit === "number" && Number.isFinite(rawLimit)
-    ? Math.max(1, Math.min(rawLimit, 10000))
-    : undefined;
+  const { region, departement, all, limit } = req.body as ScrapeBody;
 
   scrapeState = { status: "running", progress: 0, total: 0, current: "" };
 
@@ -180,7 +172,7 @@ app.get("/api/duplicates/excluded-count", requireAuth, asyncHandler(async (_req,
 }));
 
 
-app.get("/api/export", requireAuth, asyncHandler(async (req, res) => {
+app.get("/api/export", requireAuth, validateQuery(exportQuerySchema), asyncHandler(async (req, res) => {
   res.setHeader("Content-Type", "text/csv; charset=utf-8");
   res.setHeader("Content-Disposition", "attachment; filename=export.csv");
 
@@ -194,7 +186,7 @@ app.get("/api/export", requireAuth, asyncHandler(async (req, res) => {
 
   res.write("siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,forme_juridique,dirigeants,source,scraped_at\n");
 
-  for await (const r of streamAll(parseFilters(req.query as Record<string, unknown>))) {
+  for await (const r of streamAll(pickFilters(req.query as unknown as ExportQuery))) {
     const row = [r.siret, r.nom, r.adresse, r.ville, r.codePostal, r.telephone, r.effectifTranche, r.formeJuridique, r.dirigeants, r.source, r.scraped_at]
       .map(escape)
       .join(",");

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import express, { type Request, type Response, type NextFunction, type RequestHa
 import { toNodeHandler, fromNodeHeaders } from "better-auth/node";
 import { auth } from "./auth";
 import { requireAuth, dashboardGuard, alreadyAuthGuard } from "./middleware/auth";
-import { validateBody, validateQuery } from "./middleware/validate";
+import { validateBody, validateQuery, getValidatedQuery } from "./middleware/validate";
 import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
 import { runPipeline } from "./pipeline";
@@ -98,8 +98,8 @@ app.get("/api/filters", requireAuth, asyncHandler(async (_req, res) => {
   res.json(await getFilterOptions());
 }));
 
-app.get("/api/results", requireAuth, validateQuery(resultsQuerySchema), asyncHandler(async (req, res) => {
-  const query = req.query as unknown as ResultsQuery;
+app.get("/api/results", requireAuth, validateQuery(resultsQuerySchema), asyncHandler(async (_req, res) => {
+  const query = getValidatedQuery<ResultsQuery>(res);
   res.json(await getPaginated(query.page, query.limit, pickFilters(query)));
 }));
 
@@ -186,7 +186,7 @@ app.get("/api/export", requireAuth, validateQuery(exportQuerySchema), asyncHandl
 
   res.write("siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,forme_juridique,dirigeants,source,scraped_at\n");
 
-  for await (const r of streamAll(pickFilters(req.query as unknown as ExportQuery))) {
+  for await (const r of streamAll(pickFilters(getValidatedQuery<ExportQuery>(res)))) {
     const row = [r.siret, r.nom, r.adresse, r.ville, r.codePostal, r.telephone, r.effectifTranche, r.formeJuridique, r.dirigeants, r.source, r.scraped_at]
       .map(escape)
       .join(",");

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -68,7 +68,7 @@ export interface FetchOptions {
 
 // --- Helpers ---
 
-function normalizeRegion(name: string): string {
+export function normalizeRegion(name: string): string {
   return name
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")


### PR DESCRIPTION
## Contexte

Closes #39

Les paramètres API (`region`, `departement`, `limit`, filtres de `/api/results` et `/api/export`) étaient passés à la couche SIRENE (requête Lucene) et SQL sans validation côté serveur. Cette PR introduit une validation Zod centralisée qui rejette les inputs invalides avec un `400` explicite.

## Changements

### Schémas (`src/schemas/`)
- `scrape.schema.ts` — body de `POST /api/scrape` : `region` (valeur autorisée via `REGIONS_DEPARTEMENTS` + `normalizeRegion`), `departement` (regex `^\d{2,3}$|^2[AB]$` + existence dans la liste), `all` (boolean), `limit` (entier 1-10000). Contrainte : `region`, `departement` et `all` mutuellement exclusifs.
- `filters.schema.ts` — query `GET /api/results` et `GET /api/export` : filtres stricts + `page` / `limit` coercés avec défauts.
- `billing.schema.ts` — schéma préparatoire pour le webhook Polar (non branché dans cette PR).

### Middlewares (`src/middleware/validate.ts`)
- `validateBody(schema)` : parse `req.body`, remplace par la version validée.
- `validateQuery(schema)` : parse `req.query`, stocke le résultat dans `res.locals.query` (ne casse pas le type `ParsedQs` d'Express 4). Helper `getValidatedQuery<T>(res)` pour la lecture typée.
- Erreur : `400 { error: "Validation failed", issues: [{ path, message }] }`.

### Routes branchées (`src/server.ts`)
- `POST /api/scrape` → `validateBody(scrapeBodySchema)`
- `GET /api/results` → `validateQuery(resultsQuerySchema)`
- `GET /api/export` → `validateQuery(exportQuerySchema)`

### Autres
- `ResultFilters` reste défini côté DB ; mapping query → filters dans `pickFilters`.
- `normalizeRegion` exportée depuis `src/sirene.ts` pour réutilisation dans le schéma Zod.

## Critères d'acceptance

- [x] `zod` installé
- [x] Tous les inputs API validés via schéma Zod
- [x] Erreur 400 avec message explicite (champ + raison) si input invalide
- [x] Pas de string "raw" passée à `buildQuery()` SIRENE sans validation préalable
- [x] Les valeurs valides continuent de fonctionner normalement

## Test plan

- [ ] `POST /api/scrape` avec `{ "region": "narnia" }` → 400 avec `issues[0].path = "region"`
- [ ] `POST /api/scrape` avec `{ "limit": 99999 }` → 400 (avant : tronqué silencieusement)
- [ ] `POST /api/scrape` avec `{ "region": "bretagne", "all": true }` → 400 (exclusion mutuelle)
- [ ] `GET /api/results?departement=AB` → 400 (avant : accepté, filtre SQL vide)
- [ ] `GET /api/results?page=1&limit=10&phoneType=mobile` → 200, comportement inchangé
- [ ] `npx tsc --noEmit` passe sans erreur