### PR TITLE
[Feature] Multi-tenant — user_id sur scraped_records, cloisonnement strict (#41)

### DIFF
--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Hook Stop — vérifie que le build TypeScript passe avant de terminer
 
-ROOT="/home/x7c00/Documents/BUSINESS/scrapper"
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || dirname "$(dirname "$(dirname "$0")")")"
 cd "$ROOT"
 
 if [ -f "tsconfig.json" ] && [ -f "package.json" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ scraper/
 
 Utiliser **Postgres via Drizzle ORM** (table `scraped_records`, définie dans `src/db/schema.ts`).
 
-- Avant chaque scrape → `isKnown(siret)` vérifie dans `scraped_records` **et** `excluded`
+- Avant chaque scrape → `isKnownByUser(userId, siret)` vérifie dans `scraped_records` (scope user) **et** `excluded` (global)
 - Si oui → skip silencieux, incrémenter un compteur `already_known`
 - Si non → scraper, puis `insert(record)` avec `onConflictDoNothing`
 - La DB persiste entre les runs → relancer le script ne re-scrape jamais un établissement déjà traité

--- a/drizzle/0002_multi_tenant_scoped_records.sql
+++ b/drizzle/0002_multi_tenant_scoped_records.sql
@@ -1,0 +1,8 @@
+-- Cloisonnement strict par user : PK composite (user_id, siret), FK + NOT NULL.
+-- Les lignes legacy sans user_id (anterieures a Better Auth) sont invisibles en UI
+-- depuis la PR #67 — on les purge ici pour pouvoir appliquer NOT NULL.
+DELETE FROM "scraped_records" WHERE "user_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "scraped_records" DROP CONSTRAINT "scraped_records_pkey";--> statement-breakpoint
+ALTER TABLE "scraped_records" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "scraped_records" ADD CONSTRAINT "scraped_records_user_id_siret_pk" PRIMARY KEY("user_id","siret");--> statement-breakpoint
+ALTER TABLE "scraped_records" ADD CONSTRAINT "scraped_records_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/0002_multi_tenant_scoped_records.sql
+++ b/drizzle/0002_multi_tenant_scoped_records.sql
@@ -1,7 +1,14 @@
 -- Cloisonnement strict par user : PK composite (user_id, siret), FK + NOT NULL.
 -- Les lignes legacy sans user_id (anterieures a Better Auth) sont invisibles en UI
--- depuis la PR #67 — on les purge ici pour pouvoir appliquer NOT NULL.
-DELETE FROM "scraped_records" WHERE "user_id" IS NULL;--> statement-breakpoint
+-- depuis la PR #67. On refuse la migration si elles existent encore : c'est a
+-- l'operateur de les rattacher a un user ou de les supprimer manuellement,
+-- apres backup, pour eviter toute perte silencieuse.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "scraped_records" WHERE "user_id" IS NULL) THEN
+    RAISE EXCEPTION 'scraped_records contient des lignes sans user_id. Faire un backup (pg_dump -t scraped_records), puis rattacher ou supprimer manuellement avant de rejouer cette migration.';
+  END IF;
+END $$;--> statement-breakpoint
 ALTER TABLE "scraped_records" DROP CONSTRAINT "scraped_records_pkey";--> statement-breakpoint
 ALTER TABLE "scraped_records" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "scraped_records" ADD CONSTRAINT "scraped_records_user_id_siret_pk" PRIMARY KEY("user_id","siret");--> statement-breakpoint

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,811 @@
+{
+  "id": "15cea30f-fca4-4bee-9cef-33277806cc0f",
+  "prevId": "6dec7d7e-39e1-4170-a59f-a0cc6f729f80",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_transactions": {
+      "name": "credit_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polar_order_id": {
+          "name": "polar_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_tx_user_created_idx": {
+          "name": "credit_tx_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_transactions_user_id_user_id_fk": {
+          "name": "credit_transactions_user_id_user_id_fk",
+          "tableFrom": "credit_transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_tx_type_check": {
+          "name": "credit_tx_type_check",
+          "value": "\"credit_transactions\".\"type\" IN ('purchase', 'consume', 'refund', 'admin_grant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credits": {
+      "name": "credits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credits_user_id_user_id_fk": {
+          "name": "credits_user_id_user_id_fk",
+          "tableFrom": "credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.excluded": {
+      "name": "excluded",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phone_cache": {
+      "name": "phone_cache",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phone_cache_scraped_at_idx": {
+          "name": "phone_cache_scraped_at_idx",
+          "columns": [
+            {
+              "expression": "scraped_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professions": {
+      "name": "professions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "libelle": {
+          "name": "libelle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "naf_codes": {
+          "name": "naf_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "professions_libelle_unique": {
+          "name": "professions_libelle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "libelle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraped_records": {
+      "name": "scraped_records",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nom": {
+          "name": "nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ville": {
+          "name": "ville",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_postal": {
+          "name": "code_postal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effectif_tranche": {
+          "name": "effectif_tranche",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forme_juridique": {
+          "name": "forme_juridique",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dirigeants": {
+          "name": "dirigeants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraped_records_user_id_idx": {
+          "name": "scraped_records_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_source_idx": {
+          "name": "scraped_records_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_code_postal_idx": {
+          "name": "scraped_records_code_postal_idx",
+          "columns": [
+            {
+              "expression": "code_postal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_telephone_idx": {
+          "name": "scraped_records_telephone_idx",
+          "columns": [
+            {
+              "expression": "telephone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scraped_records_user_id_user_id_fk": {
+          "name": "scraped_records_user_id_user_id_fk",
+          "tableFrom": "scraped_records",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scraped_records_user_id_siret_pk": {
+          "name": "scraped_records_user_id_siret_pk",
+          "columns": [
+            "user_id",
+            "siret"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776592077335,
       "tag": "0001_auth_better_auth",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776631243925,
+      "tag": "0002_multi_tenant_scoped_records",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -195,6 +196,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -211,6 +213,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -227,6 +230,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -243,6 +247,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -259,6 +264,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -275,6 +281,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -291,6 +298,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -307,6 +315,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -323,6 +332,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -339,6 +349,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -355,6 +366,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -371,6 +383,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -387,6 +400,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -403,6 +417,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -419,6 +434,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -435,6 +451,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -451,6 +468,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -467,6 +485,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -483,6 +502,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -499,6 +519,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -515,6 +536,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -581,6 +603,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -597,6 +620,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -613,6 +637,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -629,6 +654,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -645,6 +671,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -661,6 +688,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -677,6 +705,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -693,6 +722,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -709,6 +739,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -725,6 +756,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -741,6 +773,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -757,6 +790,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -773,6 +807,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -789,6 +824,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -805,6 +841,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -821,6 +858,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -837,6 +875,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -853,6 +892,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -869,6 +909,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -885,6 +926,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -901,6 +943,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -917,6 +960,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -933,6 +977,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -949,6 +994,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -965,6 +1011,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -981,6 +1028,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2088,6 +2136,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2937,6 +2986,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2953,6 +3003,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2969,6 +3020,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2985,6 +3037,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3001,6 +3054,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3017,6 +3071,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3033,6 +3088,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3049,6 +3105,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3065,6 +3122,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3081,6 +3139,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3097,6 +3156,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3113,6 +3173,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3129,6 +3190,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3145,6 +3207,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3161,6 +3224,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3177,6 +3241,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3193,6 +3258,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3209,6 +3275,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3225,6 +3292,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3241,6 +3309,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3257,6 +3326,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3273,6 +3343,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3289,6 +3360,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3305,6 +3377,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3321,6 +3394,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3337,6 +3411,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -7,6 +7,7 @@ import {
   boolean,
   index,
   check,
+  primaryKey,
 } from "drizzle-orm/pg-core";
 import { sql, type InferSelectModel, type InferInsertModel } from "drizzle-orm";
 
@@ -73,13 +74,14 @@ export const verification = pgTable("verification", {
 });
 
 // Scraped records — une fiche entreprise enrichie par SIRENE + Google Maps.
-// `userId` est nullable le temps que #37 (Better Auth) crée la table `users` ;
-// #41 activera la FK et le NOT NULL.
+// PK composite (user_id, siret) : chaque user possede ses propres fiches,
+// deux users peuvent scraper le meme SIRET sans collision.
+// excluded reste globale pour l'instant (refonte multi-tenant complete prevue #66).
 export const scrapedRecords = pgTable(
   "scraped_records",
   {
-    siret:           text("siret").primaryKey(),
-    userId:          text("user_id"),
+    siret:           text("siret").notNull(),
+    userId:          text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
     nom:             text("nom"),
     adresse:         text("adresse"),
     ville:           text("ville"),
@@ -92,6 +94,7 @@ export const scrapedRecords = pgTable(
     scrapedAt:       timestamp("scraped_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
+    primaryKey({ columns: [t.userId, t.siret] }),
     index("scraped_records_user_id_idx").on(t.userId),
     index("scraped_records_source_idx").on(t.source),
     index("scraped_records_code_postal_idx").on(t.codePostal),

--- a/src/db/scraped.ts
+++ b/src/db/scraped.ts
@@ -28,7 +28,7 @@ export interface ScrapedRecord {
   formeJuridique:  string;
   dirigeants:      string | null;
   source:          string;
-  scraped_at:      string;
+  scrapedAt:       string;
 }
 
 export interface ScrapedStats {
@@ -63,6 +63,12 @@ const EFFECTIF_LABELS: Record<string, string> = {
   "32": "250-499 sal.",
 };
 
+// Echappe les wildcards LIKE/ILIKE (%, _, \) dans la saisie utilisateur pour
+// eviter que "M_ie" matche tout nom de 4 lettres ou que "100%" soit imprevisible.
+function escapeLike(input: string): string {
+  return input.replace(/[\\%_]/g, "\\$&");
+}
+
 function buildWhereClause(userId: string, filters: ResultFilters): SQL {
   const conditions: SQL[] = [eq(scrapedRecords.userId, userId)];
 
@@ -75,8 +81,8 @@ function buildWhereClause(userId: string, filters: ResultFilters): SQL {
   }
 
   if (filters.phoneType) conditions.push(phoneTypeCondition(filters.phoneType));
-  if (filters.nom?.trim())         conditions.push(ilike(scrapedRecords.nom, "%" + filters.nom.trim() + "%"));
-  if (filters.ville?.trim())       conditions.push(ilike(scrapedRecords.ville, "%" + filters.ville.trim() + "%"));
+  if (filters.nom?.trim())         conditions.push(ilike(scrapedRecords.nom, `%${escapeLike(filters.nom.trim())}%`));
+  if (filters.ville?.trim())       conditions.push(ilike(scrapedRecords.ville, `%${escapeLike(filters.ville.trim())}%`));
   if (filters.effectif?.trim())    conditions.push(eq(scrapedRecords.effectifTranche, filters.effectif.trim()));
   if (filters.departement?.trim()) conditions.push(like(scrapedRecords.codePostal, filters.departement.trim() + "%"));
   if (filters.formeJuridique?.trim()) conditions.push(eq(scrapedRecords.formeJuridique, filters.formeJuridique.trim()));
@@ -110,7 +116,7 @@ function toRecord(row: {
     formeJuridique:  row.formeJuridique ?? "",
     dirigeants:      row.dirigeants,
     source:          row.source,
-    scraped_at:      row.scrapedAt.toISOString(),
+    scrapedAt:       row.scrapedAt.toISOString(),
   };
 }
 
@@ -146,7 +152,7 @@ export async function insert(record: ScrapedRecord): Promise<void> {
       formeJuridique: record.formeJuridique,
       dirigeants: record.dirigeants,
       source: record.source,
-      scrapedAt: new Date(record.scraped_at),
+      scrapedAt: new Date(record.scrapedAt),
     })
     .onConflictDoNothing({ target: [scrapedRecords.userId, scrapedRecords.siret] });
 }
@@ -202,8 +208,25 @@ function toRecordFromRaw(row: Record<string, unknown>): ScrapedRecord {
     formeJuridique:  (row.forme_juridique as string | null) ?? "",
     dirigeants:      (row.dirigeants      as string | null) ?? null,
     source:          row.source as string,
-    scraped_at:      scrapedAtIso,
+    scrapedAt:       scrapedAtIso,
   };
+}
+
+// Pont Drizzle -> postgres-js : Drizzle n'expose pas de cursor streame, donc on
+// utilise pgClient.unsafe avec la SQL et les params produits par Drizzle. Le
+// cast `params as never[]` contourne le typage interne de postgres-js et reste
+// le SEUL point de fragilite : si Drizzle change son format de serialisation
+// (dates, tableaux, UUIDs), ca compile mais crash a l'execution. A auditer a
+// chaque bump majeur de drizzle-orm.
+async function* streamDrizzleQuery<T extends Record<string, unknown>>(
+  query: { toSQL(): { sql: string; params: unknown[] } },
+  chunkSize: number,
+): AsyncIterable<T> {
+  const { sql: sqlText, params } = query.toSQL();
+  const cursor = pgClient.unsafe<T[]>(sqlText, params as never[]).cursor(chunkSize);
+  for await (const chunk of cursor) {
+    for (const row of chunk) yield row;
+  }
 }
 
 export async function* streamAll(
@@ -213,14 +236,8 @@ export async function* streamAll(
 ): AsyncIterable<ScrapedRecord> {
   const where = buildWhereClause(userId, filters);
   const query = db.select().from(scrapedRecords).where(where).orderBy(desc(scrapedRecords.scrapedAt));
-  const { sql: sqlText, params } = query.toSQL();
-
-  // Drizzle renvoie `unknown[]`, postgres-js attend son type interne — cast nécessaire pour l'interop.
-  const cursor = pgClient.unsafe(sqlText, params as never[]).cursor(chunkSize);
-  for await (const chunk of cursor) {
-    for (const row of chunk as Array<Record<string, unknown>>) {
-      yield toRecordFromRaw(row);
-    }
+  for await (const row of streamDrizzleQuery<Record<string, unknown>>(query, chunkSize)) {
+    yield toRecordFromRaw(row);
   }
 }
 
@@ -349,38 +366,39 @@ export async function getPhoneDuplicates(userId: string): Promise<PhoneDuplicate
 }
 
 export async function cleanPhoneDuplicates(userId: string): Promise<number> {
-  const phones = await db.execute<{ telephone: string }>(
-    sql`select telephone from ${scrapedRecords}
-        where ${scrapedRecords.userId} = ${userId}
-          and telephone is not null and telephone != ''
-        group by telephone
-        having count(*) > 1`,
+  const toExclude = await db.execute<{ siret: string }>(
+    sql`with ranked as (
+          select siret,
+                 row_number() over (
+                   partition by telephone
+                   order by case when source != 'non_trouvé' then 0 else 1 end,
+                            scraped_at desc
+                 ) as rn
+          from ${scrapedRecords}
+          where user_id = ${userId}
+            and telephone is not null and telephone != ''
+            and telephone in (
+              select telephone from ${scrapedRecords}
+              where user_id = ${userId}
+                and telephone is not null and telephone != ''
+              group by telephone having count(*) > 1
+            )
+        )
+        select siret from ranked where rn > 1`,
   );
-  if (phones.length === 0) return 0;
+  if (toExclude.length === 0) return 0;
 
-  let deleted = 0;
+  const sirets = toExclude.map((r) => r.siret);
   await db.transaction(async (tx) => {
-    for (const { telephone } of phones) {
-      const rows = await tx
-        .select({ siret: scrapedRecords.siret })
-        .from(scrapedRecords)
-        .where(and(eq(scrapedRecords.userId, userId), eq(scrapedRecords.telephone, telephone)))
-        .orderBy(
-          sql`case when ${scrapedRecords.source} != 'non_trouvé' then 0 else 1 end`,
-          desc(scrapedRecords.scrapedAt),
-        );
-
-      for (let i = 1; i < rows.length; i++) {
-        const { siret } = rows[i];
-        await tx.insert(excluded).values({ siret }).onConflictDoNothing({ target: excluded.siret });
-        await tx
-          .delete(scrapedRecords)
-          .where(and(eq(scrapedRecords.siret, siret), eq(scrapedRecords.userId, userId)));
-        deleted++;
-      }
-    }
+    await tx
+      .insert(excluded)
+      .values(sirets.map((siret) => ({ siret })))
+      .onConflictDoNothing({ target: excluded.siret });
+    await tx
+      .delete(scrapedRecords)
+      .where(and(eq(scrapedRecords.userId, userId), inArray(scrapedRecords.siret, sirets)));
   });
-  return deleted;
+  return sirets.length;
 }
 
 export interface NameDuplicateGroup {

--- a/src/db/scraped.ts
+++ b/src/db/scraped.ts
@@ -17,18 +17,18 @@ export interface ResultFilters {
 }
 
 export interface ScrapedRecord {
-  siret: string;
-  userId: string;
-  nom: string;
-  adresse: string;
-  ville: string;
-  codePostal: string;
-  telephone: string | null;
+  siret:           string;
+  userId:          string;
+  nom:             string;
+  adresse:         string;
+  ville:           string;
+  codePostal:      string;
+  telephone:       string | null;
   effectifTranche: string;
-  formeJuridique: string;
-  dirigeants: string | null;
-  source: string;
-  scraped_at: string;
+  formeJuridique:  string;
+  dirigeants:      string | null;
+  source:          string;
+  scraped_at:      string;
 }
 
 export interface ScrapedStats {
@@ -85,41 +85,47 @@ function buildWhereClause(userId: string, filters: ResultFilters): SQL {
 }
 
 function toRecord(row: {
-  siret: string;
-  userId: string | null;
-  nom: string | null;
-  adresse: string | null;
-  ville: string | null;
-  codePostal: string | null;
-  telephone: string | null;
+  siret:           string;
+  userId:          string;
+  nom:             string | null;
+  adresse:         string | null;
+  ville:           string | null;
+  codePostal:      string | null;
+  telephone:       string | null;
   effectifTranche: string | null;
-  formeJuridique: string | null;
-  dirigeants: string | null;
-  source: string;
-  scrapedAt: Date;
+  formeJuridique:  string | null;
+  dirigeants:      string | null;
+  source:          string;
+  scrapedAt:       Date;
 }): ScrapedRecord {
   return {
-    siret: row.siret,
-    userId: row.userId ?? "",
-    nom: row.nom ?? "",
-    adresse: row.adresse ?? "",
-    ville: row.ville ?? "",
-    codePostal: row.codePostal ?? "",
-    telephone: row.telephone,
+    siret:           row.siret,
+    userId:          row.userId,
+    nom:             row.nom ?? "",
+    adresse:         row.adresse ?? "",
+    ville:           row.ville ?? "",
+    codePostal:      row.codePostal ?? "",
+    telephone:       row.telephone,
     effectifTranche: row.effectifTranche ?? "",
-    formeJuridique: row.formeJuridique ?? "",
-    dirigeants: row.dirigeants,
-    source: row.source,
-    scraped_at: row.scrapedAt.toISOString(),
+    formeJuridique:  row.formeJuridique ?? "",
+    dirigeants:      row.dirigeants,
+    source:          row.source,
+    scraped_at:      row.scrapedAt.toISOString(),
   };
 }
 
 // No-op conservé pour compatibilité — les migrations sont gérées par drizzle-kit.
 export function initDb(): void {}
 
-export async function isKnown(siret: string): Promise<boolean> {
+// Scope par user : deux users peuvent avoir la meme fiche SIRET independamment.
+// `excluded` reste globale pour cette issue (refonte prevue #66).
+export async function isKnownByUser(userId: string, siret: string): Promise<boolean> {
   const [scraped, excl] = await Promise.all([
-    db.select({ one: sql`1` }).from(scrapedRecords).where(eq(scrapedRecords.siret, siret)).limit(1),
+    db
+      .select({ one: sql`1` })
+      .from(scrapedRecords)
+      .where(and(eq(scrapedRecords.userId, userId), eq(scrapedRecords.siret, siret)))
+      .limit(1),
     db.select({ one: sql`1` }).from(excluded).where(eq(excluded.siret, siret)).limit(1),
   ]);
   return scraped.length > 0 || excl.length > 0;
@@ -142,7 +148,7 @@ export async function insert(record: ScrapedRecord): Promise<void> {
       source: record.source,
       scrapedAt: new Date(record.scraped_at),
     })
-    .onConflictDoNothing({ target: scrapedRecords.siret });
+    .onConflictDoNothing({ target: [scrapedRecords.userId, scrapedRecords.siret] });
 }
 
 export async function getStats(userId: string): Promise<ScrapedStats> {
@@ -186,7 +192,7 @@ function toRecordFromRaw(row: Record<string, unknown>): ScrapedRecord {
     scrapedAt instanceof Date ? scrapedAt.toISOString() : new Date(String(scrapedAt)).toISOString();
   return {
     siret:           row.siret as string,
-    userId:          (row.user_id         as string | null) ?? "",
+    userId:          row.user_id as string,
     nom:             (row.nom             as string | null) ?? "",
     adresse:         (row.adresse         as string | null) ?? "",
     ville:           (row.ville           as string | null) ?? "",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -62,18 +62,6 @@ export const alreadyAuthGuard: RequestHandler = (req, res, next) => {
     .catch(next);
 };
 
-export const requireAdmin: RequestHandler = (req, res, next) => {
-  if (!req.user) {
-    res.status(401).json({ error: "Unauthorized" });
-    return;
-  }
-  if (req.user.role !== "admin") {
-    res.status(403).json({ error: "Forbidden" });
-    return;
-  }
-  next();
-};
-
 export const requireAdminAuth: RequestHandler = (req, res, next) => {
   auth.api
     .getSession({ headers: fromNodeHeaders(req.headers) })

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,5 +1,5 @@
 import { Etablissement } from "./sirene";
-import { isKnown, insert, ScrapedRecord } from "./db/scraped";
+import { isKnownByUser, insert, ScrapedRecord } from "./db/scraped";
 import { findPhoneGoogle } from "./googleMaps";
 import { fetchDirigeants } from "./annuaireEntreprises";
 
@@ -25,7 +25,7 @@ export async function runPipeline(
   let i = 0;
 
   for await (const etab of source) {
-      if (await isKnown(etab.siret)) {
+      if (await isKnownByUser(userId, etab.siret)) {
         alreadyKnown++;
         continue;
       }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -25,12 +25,12 @@ export async function runPipeline(
   let i = 0;
 
   for await (const etab of source) {
+      if (limit !== undefined && newCount + notFoundCount >= limit) break;
+
       if (await isKnownByUser(userId, etab.siret)) {
         alreadyKnown++;
         continue;
       }
-
-      if (limit !== undefined && newCount + notFoundCount >= limit) break;
 
       onProgress?.(++i, etab.nom);
 
@@ -58,7 +58,7 @@ export async function runPipeline(
         formeJuridique: etab.formeJuridique,
         dirigeants,
         source: scrapeSource,
-        scraped_at: new Date().toISOString(),
+        scrapedAt: new Date().toISOString(),
       };
 
       await insert(record);

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1205,7 +1205,7 @@
         var tdSiret  = document.createElement("td"); tdSiret.style.fontFamily = "var(--mono)"; tdSiret.textContent = r.siret;
         var tdTel    = document.createElement("td"); tdTel.textContent = r.telephone || "—";
         var tdSource = document.createElement("td"); tdSource.textContent = r.source;
-        var tdDate   = document.createElement("td"); tdDate.textContent = r.scraped_at ? r.scraped_at.slice(0, 10) : "—";
+        var tdDate   = document.createElement("td"); tdDate.textContent = r.scrapedAt ? r.scrapedAt.slice(0, 10) : "—";
 
         tr.style.opacity = kept ? "1" : "0.5";
         tr.append(tdStatus, tdNom, tdVille, tdSiret, tdTel, tdSource, tdDate);

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ interface ScrapeState {
   progress: number;
   total: number;
   current: string;
+  error?: string;
   result?: { newCount: number; alreadyKnown: number; notFoundCount: number };
 }
 
@@ -144,7 +145,7 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), (req, res) 
     };
   })().catch((err) => {
     state.status = "done";
-    state.current = `Erreur : ${err instanceof Error ? err.message : String(err)}`;
+    state.error = err instanceof Error ? err.message : String(err);
   });
 
   res.json({ message: "Scrape lancé" });
@@ -192,7 +193,7 @@ app.get("/api/export", requireAuth, validateQuery(exportQuerySchema), asyncHandl
   res.write("siret,nom,adresse,ville,code_postal,telephone,effectif_tranche,forme_juridique,dirigeants,source,scraped_at\n");
 
   for await (const r of streamAll(req.user!.id, pickFilters(getValidatedQuery<ExportQuery>(res)))) {
-    const row = [r.siret, r.nom, r.adresse, r.ville, r.codePostal, r.telephone, r.effectifTranche, r.formeJuridique, r.dirigeants, r.source, r.scraped_at]
+    const row = [r.siret, r.nom, r.adresse, r.ville, r.codePostal, r.telephone, r.effectifTranche, r.formeJuridique, r.dirigeants, r.source, r.scrapedAt]
       .map(escape)
       .join(",");
     res.write(row + "\n");


### PR DESCRIPTION
## Contexte

La PR #67 (issue #40) avait introduit `userId` dans toutes les fonctions de `src/db/scraped.ts` et scopé les queries. Cette PR verrouille le cloisonnement au niveau schéma et corrige la dernière fuite résiduelle qui empêchait deux users de scraper le même SIRET.

Closes #41

## Ce qui a été fait

`scraped_records.user_id` est maintenant `NOT NULL` avec FK `user(id) ON DELETE CASCADE` et une PK composite `(user_id, siret)` : deux users peuvent avoir chacun leur fiche du même SIRET, et supprimer un compte purge automatiquement ses fiches.

`isKnownByUser(userId, siret)` remplace l'ancien `isKnown(siret)` global : la déduplication est strictement scopée par user, avec vérification parallèle dans `scraped_records` (scope user) et `excluded` (global).

La migration 0002 refuse de s'appliquer si des données legacy sans `user_id` existent encore (`RAISE EXCEPTION`) pour forcer une décision manuelle avant de rendre la colonne NOT NULL.

## Fichiers modifiés

- `src/db/schema.ts` — PK composite `(user_id, siret)`, FK cascade, `user_id NOT NULL`
- `drizzle/0002_multi_tenant_scoped_records.sql` — migration avec `RAISE EXCEPTION` si données legacy
- `src/db/scraped.ts` — `isKnownByUser`, `onConflictDoNothing` sur PK composite, `cleanPhoneDuplicates` batchée, helper `streamDrizzleQuery`, `escapeLike` sur ILIKE, rename `scraped_at → scrapedAt`
- `src/pipeline.ts` — `isKnownByUser` + guard `limit` avant le skip `alreadyKnown`
- `src/middleware/auth.ts` — suppression de `requireAdmin` inutilisé
- `src/server.ts` — `ScrapeState.error?` pour distinguer fin normale et erreur
- `CLAUDE.md` — doc alignée sur `isKnownByUser`

## Points de review

- `excluded` reste volontairement globale (refonte multi-tenant complète prévue dans #66)
- L'index `scraped_records_user_id_idx` est conservé : partiellement redondant avec la PK composite mais utile pour les scans `WHERE user_id = X` seul
- `streamDrizzleQuery` isole le seul cast `pgClient.unsafe(params as never[])` du codebase — à auditer à chaque bump majeur de `drizzle-orm`

## Tests

- `npx tsc --noEmit` passe sans erreur
- Migration `npm run db:migrate` applique la 0002 sans erreur
- `\d scraped_records` montre la PK composite, la FK cascade et `user_id NOT NULL`
- User A scrape SIRET S → user B rescrape la même région → fiche S présente pour les deux indépendamment
- `DELETE FROM "user" WHERE id = X` cascade sur les fiches scrapées
- `isKnownByUser` retourne false pour un SIRET déjà connu d'un autre user
