### PR TITLE
[Refactor] scrapeState Map keyed by userId (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING** — La base de données passe de SQLite à Postgres. L'application nécessite désormais une `DATABASE_URL` ; en local, lancer `docker compose up -d db` puis `npm run db:migrate` avant de démarrer le serveur. L'ancienne base `data/scraper.db` n'est pas migrée (décision produit : on repart from scratch) ([`8b7a160`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8b7a160), [`9b0b101`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/9b0b101), [`fe0569b`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/fe0569b))
+- **BREAKING** — Migration requise : `scraped_records` passe à une clé primaire composite `(user_id, siret)` avec contrainte FK `user_id → user.id` (cascade delete) ; lancer `npm run db:migrate` avant de démarrer cette version ([#68](https://github.com/alex-robert-fr/entreprise-scrapper/pull/68))
 
 ### Fixed
 

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `src/db/scraped.ts` : toutes les fonctions publiques reçoivent `userId: string` en premier argument ; `buildWhereClause` filtre systématiquement par `user_id` ; les `DELETE` dans `cleanPhoneDuplicates`/`cleanNameDuplicates` incluent le scope `userId` en défense en profondeur ([`3d004ce`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/3d004ce), [`063fd61`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/063fd61))
 - `src/server.ts` : `scrapeState` devient `Map<userId, ScrapeState>` pour isoler le statut de scrape par utilisateur ; `/api/health` bascule sur `SELECT 1` indépendant du scope user ([`8c19bf6`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8c19bf6), [`063fd61`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/063fd61))
 - `src/pipeline.ts` : signature `runPipeline(source, userId, onProgress?, limit?)` — `userId` propagé à chaque `ScrapedRecord` inséré ([`3442b43`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/3442b43))
+- `src/db/scraped.ts` : `isKnownByUser(userId, siret)` remplace la déduplication globale par SIRET seul ; schéma `scraped_records` passe à une PK composite `(user_id, siret)` avec FK `user_id → user.id` et cascade delete ([#68](https://github.com/alex-robert-fr/entreprise-scrapper/pull/68))
+- `src/server.ts` : cleanup périodique de `scrapeStates` (purge toutes les 5 min les états terminés depuis > 1h, `setInterval` avec `.unref()` et désactivé en `NODE_ENV=test`) ; `finishedAt` ajouté à `ScrapeState` pour tracer la fin du scrape ; shutdown propre via `server.close()` sur SIGINT/SIGTERM ; `getScrapeState` retourne une copie de `IDLE_STATE` pour éviter toute mutation partagée ([#69](https://github.com/alex-robert-fr/entreprise-scrapper/pull/69))
 
 ### Docs
 
@@ -27,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CLAUDE.md` : structure projet et système de déduplication mis à jour ; codes INSEE effectif corrigés (11, 12, 21, 22, 31, 32) ([`d57246e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/d57246e), [`733402e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/733402e))
 - `.claude/skills/tech-stack/SKILL.md` : stack DB mise à jour (Postgres + Drizzle) ([`d57246e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/d57246e))
 - `.env.example` : `SCRAPE_USER_ID` documenté pour la CLI (usage futur quand `src/main.ts` sera implémenté) ([`1701c1a`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/1701c1a))
+- `CLAUDE.md` mis à jour pour refléter `isKnownByUser` comme interface de déduplication ([`a7d0b65`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/a7d0b65))
 
 ### Dependencies
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ interface ScrapeState {
   current: string;
   error?: string;
   result?: { newCount: number; alreadyKnown: number; notFoundCount: number };
+  finishedAt?: number;
 }
 
 const IDLE_STATE: ScrapeState = { status: "idle", progress: 0, total: 0, current: "" };
@@ -143,9 +144,11 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), (req, res) 
       alreadyKnown: result.alreadyKnown,
       notFoundCount: result.notFoundCount,
     };
+    state.finishedAt = Date.now();
   })().catch((err) => {
     state.status = "done";
     state.error = err instanceof Error ? err.message : String(err);
+    state.finishedAt = Date.now();
   });
 
   res.json({ message: "Scrape lancé" });

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,12 +45,15 @@ const CLEANUP_TTL_MS = 60 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 
 function getScrapeState(userId: string): ScrapeState {
-  return scrapeStates.get(userId) ?? IDLE_STATE;
+  return scrapeStates.get(userId) ?? { ...IDLE_STATE };
 }
 
 function cleanupFinishedStates(now: number = Date.now()) {
   for (const [userId, state] of scrapeStates) {
-    if (state.status !== "running" && state.finishedAt !== undefined && now - state.finishedAt > CLEANUP_TTL_MS) {
+    if (
+      state.status !== "running" &&
+      (state.finishedAt === undefined || now - state.finishedAt > CLEANUP_TTL_MS)
+    ) {
       scrapeStates.delete(userId);
     }
   }
@@ -226,13 +229,13 @@ app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
   res.status(500).json({ error: "Erreur serveur" });
 });
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`Dashboard disponible sur http://localhost:${PORT}`);
 });
 
 function shutdown() {
   if (cleanupTimer) clearInterval(cleanupTimer);
-  process.exit(0);
+  server.close(() => process.exit(0));
 }
 process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,9 +41,24 @@ interface ScrapeState {
 const IDLE_STATE: ScrapeState = { status: "idle", progress: 0, total: 0, current: "" };
 const scrapeStates = new Map<string, ScrapeState>();
 
+const CLEANUP_TTL_MS = 60 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
 function getScrapeState(userId: string): ScrapeState {
   return scrapeStates.get(userId) ?? IDLE_STATE;
 }
+
+function cleanupFinishedStates(now: number = Date.now()) {
+  for (const [userId, state] of scrapeStates) {
+    if (state.status !== "running" && state.finishedAt !== undefined && now - state.finishedAt > CLEANUP_TTL_MS) {
+      scrapeStates.delete(userId);
+    }
+  }
+}
+
+const cleanupTimer =
+  process.env.NODE_ENV === "test" ? null : setInterval(cleanupFinishedStates, CLEANUP_INTERVAL_MS);
+cleanupTimer?.unref();
 
 // Better Auth doit lire le body brut — monté AVANT express.json()
 app.all("/api/auth/*", toNodeHandler(auth));
@@ -214,3 +229,10 @@ app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
 app.listen(PORT, () => {
   console.log(`Dashboard disponible sur http://localhost:${PORT}`);
 });
+
+function shutdown() {
+  if (cleanupTimer) clearInterval(cleanupTimer);
+  process.exit(0);
+}
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);


### PR DESCRIPTION
## Contexte

Closes #42

La `Map<userId, ScrapeState>` et les routes per-user étaient déjà en place.
Ce PR implémente le dernier critère d'acceptance manquant : le cleanup périodique
pour éviter la fuite mémoire.

## Changements

- Ajout du champ `finishedAt` sur `ScrapeState`, posé quand le scrape passe
  à `done` (succès et erreur)
- `cleanupFinishedStates` : purge toutes les 5 min les entrées terminées
  depuis > 1h, ou sans `finishedAt` (entrées legacy)
- `setInterval` avec `.unref()` + désactivé en `NODE_ENV=test`
- Shutdown propre via `server.close()` sur SIGINT/SIGTERM avant `process.exit(0)`
- `getScrapeState` retourne un spread de `IDLE_STATE` pour éviter toute mutation partagée

## Critères d'acceptance

- [x] Chaque utilisateur a son propre état de scrape indépendant
- [x] `GET /api/status` retourne uniquement l'état du scrape de l'utilisateur courant
- [x] Deux scrapes simultanés de deux utilisateurs différents sont possibles
- [x] Un utilisateur ne peut toujours pas lancer deux scrapes en parallèle (409 conservé)
- [x] La Map ne fuit pas en mémoire (cleanup des entrées terminées)