### PR TITLE
[Feature] Table professions + seed 20 métiers populaires (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Authentification par email/password et Google OAuth disponible sur `/api/auth/*` : signup, signin, signout avec cookie de session `HttpOnly` (secure en production) ; 50 crédits offerts automatiquement à l'inscription ([`8613e41`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8613e41))
 - `GET /api/me` — retourne la session courante de l'utilisateur connecté ; `401 Unauthorized` si non authentifié ([`8613e41`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8613e41))
 - Pages `/login` et `/signup` disponibles : formulaire email/password + bouton Google OAuth, redirection vers `/` après authentification réussie ; un utilisateur déjà connecté accédant à ces pages est automatiquement redirigé vers `/` ([`9abac3e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/9abac3e))
+- `GET /api/professions` — retourne la liste des 20 métiers actifs (`slug`, `libelle`, `nafCodes`, `category`) pré-seedés et catégorisés (Alimentation, BTP, Santé, Services, Automobile, Commerce, Beauté) ; disponibles immédiatement après `npm run db:setup` ([#71](https://github.com/alex-robert-fr/entreprise-scrapper/pull/71))
 
 ### Changed
 

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `src/pipeline.ts` : signature `runPipeline(source, userId, onProgress?, limit?)` — `userId` propagé à chaque `ScrapedRecord` inséré ([`3442b43`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/3442b43))
 - `src/db/scraped.ts` : `isKnownByUser(userId, siret)` remplace la déduplication globale par SIRET seul ; schéma `scraped_records` passe à une PK composite `(user_id, siret)` avec FK `user_id → user.id` et cascade delete ([#68](https://github.com/alex-robert-fr/entreprise-scrapper/pull/68))
 - `src/server.ts` : cleanup périodique de `scrapeStates` (purge toutes les 5 min les états terminés depuis > 1h, `setInterval` avec `.unref()` et désactivé en `NODE_ENV=test`) ; `finishedAt` ajouté à `ScrapeState` pour tracer la fin du scrape ; shutdown propre via `server.close()` sur SIGINT/SIGTERM ; `getScrapeState` retourne une copie de `IDLE_STATE` pour éviter toute mutation partagée ([#69](https://github.com/alex-robert-fr/entreprise-scrapper/pull/69))
+- `src/db/professions.ts` : ajout de `listActiveProfessions()` — query Drizzle filtrée sur `active = true`, ordonnée par `category` puis `libelle` ([#71](https://github.com/alex-robert-fr/entreprise-scrapper/pull/71))
 
 ### Docs
 
@@ -47,5 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variable `BETTER_AUTH_TRUSTED_ORIGINS` (CSV) pour configurer plusieurs origines autorisées en plus de `BETTER_AUTH_URL` ([`0f20ef4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/0f20ef4))
 - Hook `user.create.after` : gestion d'erreur avec relance et log d'avertissement si conflit sur insert crédits ([`0f20ef4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/0f20ef4))
 - Branche par défaut basculée sur `develop` dans les skills workflow (`workflow-config`, `tech-stack`) ([`ed4eb21`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/ed4eb21))
+- Migration `0004_professions_extended.sql` : colonnes `slug` (UNIQUE), `category` et `active` ajoutées à `professions` + index `professions_category_idx` ([#71](https://github.com/alex-robert-fr/entreprise-scrapper/pull/71))
+- `package.json` : script `db:setup` (`npm run db:migrate && npm run db:seed`) pour initialiser la base en une commande ([#71](https://github.com/alex-robert-fr/entreprise-scrapper/pull/71))
 
 [Unreleased]: https://github.com/alex-robert-fr/entreprise-scrapper/compare/v0.1.0...HEAD

--- a/drizzle/0004_professions_extended.sql
+++ b/drizzle/0004_professions_extended.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "professions" ADD COLUMN "slug" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "professions" ADD COLUMN "category" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "professions" ADD COLUMN "active" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+CREATE INDEX "professions_category_idx" ON "professions" USING btree ("category");--> statement-breakpoint
+ALTER TABLE "professions" ADD CONSTRAINT "professions_slug_unique" UNIQUE("slug");

--- a/drizzle/0004_professions_extended.sql
+++ b/drizzle/0004_professions_extended.sql
@@ -1,3 +1,12 @@
+-- On ajoute slug/category en NOT NULL sans DEFAULT : Postgres refuse si la table
+-- contient deja des lignes. Le seed (#44) repopule la table, donc on exige qu'elle
+-- soit vide avant migration plutot que de laisser Postgres cracher une erreur opaque.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "professions") THEN
+    RAISE EXCEPTION 'professions n''est pas vide. TRUNCATE "professions" RESTART IDENTITY; avant de rejouer (le seed #44 repopule la table).';
+  END IF;
+END $$;--> statement-breakpoint
 ALTER TABLE "professions" ADD COLUMN "slug" text NOT NULL;--> statement-breakpoint
 ALTER TABLE "professions" ADD COLUMN "category" text NOT NULL;--> statement-breakpoint
 ALTER TABLE "professions" ADD COLUMN "active" boolean DEFAULT true NOT NULL;--> statement-breakpoint

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,799 @@
+{
+  "id": "8741a187-44ed-4833-8fcc-017970264d39",
+  "prevId": "27c68711-48fb-4392-9557-c7ae1f617b73",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_transactions": {
+      "name": "credit_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polar_order_id": {
+          "name": "polar_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_tx_user_created_idx": {
+          "name": "credit_tx_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_transactions_user_id_user_id_fk": {
+          "name": "credit_transactions_user_id_user_id_fk",
+          "tableFrom": "credit_transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_tx_type_check": {
+          "name": "credit_tx_type_check",
+          "value": "\"credit_transactions\".\"type\" IN ('purchase', 'consume', 'refund', 'admin_grant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credits": {
+      "name": "credits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credits_user_id_user_id_fk": {
+          "name": "credits_user_id_user_id_fk",
+          "tableFrom": "credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.excluded": {
+      "name": "excluded",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professions": {
+      "name": "professions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle": {
+          "name": "libelle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "naf_codes": {
+          "name": "naf_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "professions_category_idx": {
+          "name": "professions_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "professions_slug_unique": {
+          "name": "professions_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "professions_libelle_unique": {
+          "name": "professions_libelle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "libelle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraped_records": {
+      "name": "scraped_records",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nom": {
+          "name": "nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ville": {
+          "name": "ville",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_postal": {
+          "name": "code_postal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effectif_tranche": {
+          "name": "effectif_tranche",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forme_juridique": {
+          "name": "forme_juridique",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dirigeants": {
+          "name": "dirigeants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraped_records_user_id_idx": {
+          "name": "scraped_records_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_source_idx": {
+          "name": "scraped_records_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_code_postal_idx": {
+          "name": "scraped_records_code_postal_idx",
+          "columns": [
+            {
+              "expression": "code_postal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_telephone_idx": {
+          "name": "scraped_records_telephone_idx",
+          "columns": [
+            {
+              "expression": "telephone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scraped_records_user_id_user_id_fk": {
+          "name": "scraped_records_user_id_user_id_fk",
+          "tableFrom": "scraped_records",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scraped_records_user_id_siret_pk": {
+          "name": "scraped_records_user_id_siret_pk",
+          "columns": [
+            "user_id",
+            "siret"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776851561064,
       "tag": "0003_drop_phone_cache",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776853030348,
+      "tag": "0004_professions_extended",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "db:seed": "ts-node src/db/seeds/run.ts"
   },
   "dependencies": {
     "better-auth": "^1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "db:seed": "ts-node src/db/seeds/run.ts"
+    "db:seed": "ts-node src/db/seeds/run.ts",
+    "db:setup": "npm run db:migrate && npm run db:seed"
   },
   "dependencies": {
     "better-auth": "^1.2",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,2 +1,3 @@
 export * from "./schema";
 export * from "./scraped";
+export * from "./professions";

--- a/src/db/professions.ts
+++ b/src/db/professions.ts
@@ -1,0 +1,11 @@
+import { asc, eq } from "drizzle-orm";
+import { db } from "./client";
+import { professions, type ProfessionRow } from "./schema";
+
+export function listActiveProfessions(): Promise<ProfessionRow[]> {
+  return db
+    .select()
+    .from(professions)
+    .where(eq(professions.active, true))
+    .orderBy(asc(professions.category), asc(professions.libelle));
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -109,11 +109,19 @@ export const excluded = pgTable("excluded", {
 });
 
 // Métiers supportés (boulanger, pâtissier, boucher...) — seedés en #44.
-export const professions = pgTable("professions", {
-  id:       serial("id").primaryKey(),
-  libelle:  text("libelle").notNull().unique(),
-  nafCodes: text("naf_codes").array().notNull(),
-});
+// naf_codes stockés sans point (format SIRENE "1071C", pas "10.71C") pour matcher directement l'API.
+export const professions = pgTable(
+  "professions",
+  {
+    id:       serial("id").primaryKey(),
+    slug:     text("slug").notNull().unique(),
+    libelle:  text("libelle").notNull().unique(),
+    nafCodes: text("naf_codes").array().notNull(),
+    category: text("category").notNull(),
+    active:   boolean("active").notNull().default(true),
+  },
+  (t) => [index("professions_category_idx").on(t.category)],
+);
 
 // Solde de crédits par user (1 fiche affichée = 1 crédit consommé en #47).
 export const credits = pgTable("credits", {

--- a/src/db/seeds/professions.ts
+++ b/src/db/seeds/professions.ts
@@ -1,0 +1,51 @@
+import type { Db } from "../client";
+import { professions, type NewProfession } from "../schema";
+
+// Codes NAF stockés sans point pour matcher directement SIRENE (ex: "1071C", pas "10.71C").
+export const PROFESSIONS_SEED: NewProfession[] = [
+  { slug: "boulanger",     libelle: "Boulangerie-Pâtisserie",     nafCodes: ["1071C", "1071D"], category: "Alimentation", active: true },
+  { slug: "restaurateur",  libelle: "Restauration traditionnelle", nafCodes: ["5610A"],          category: "Alimentation", active: true },
+  { slug: "boucher",       libelle: "Boucherie-Charcuterie",      nafCodes: ["4722Z", "1013B"], category: "Alimentation", active: true },
+  { slug: "fleuriste",     libelle: "Fleuriste",                   nafCodes: ["4776Z"],          category: "Alimentation", active: true },
+
+  { slug: "plombier",      libelle: "Plombier-Chauffagiste",       nafCodes: ["4322A", "4322B"], category: "BTP",          active: true },
+  { slug: "macon",         libelle: "Maçon",                       nafCodes: ["4399C", "4120A"], category: "BTP",          active: true },
+  { slug: "electricien",   libelle: "Électricien",                 nafCodes: ["4321A"],          category: "BTP",          active: true },
+  { slug: "menuisier",     libelle: "Menuiserie",                  nafCodes: ["4332A", "1623Z"], category: "BTP",          active: true },
+
+  { slug: "garagiste",     libelle: "Garage automobile",           nafCodes: ["4520A", "4520B"], category: "Automobile",   active: true },
+  { slug: "auto-ecole",    libelle: "Auto-école",                  nafCodes: ["8553Z"],          category: "Automobile",   active: true },
+
+  { slug: "pharmacien",    libelle: "Pharmacie",                   nafCodes: ["4773Z"],          category: "Sante",        active: true },
+  { slug: "dentiste",      libelle: "Cabinet dentaire",            nafCodes: ["8623Z"],          category: "Sante",        active: true },
+  { slug: "medecin",       libelle: "Cabinet médical",             nafCodes: ["8621Z"],          category: "Sante",        active: true },
+  { slug: "veterinaire",   libelle: "Vétérinaire",                 nafCodes: ["7500Z"],          category: "Sante",        active: true },
+  { slug: "opticien",      libelle: "Opticien",                    nafCodes: ["4778A"],          category: "Sante",        active: true },
+
+  { slug: "coiffeur",      libelle: "Coiffure",                    nafCodes: ["9602A"],          category: "Beaute",       active: true },
+
+  { slug: "avocat",        libelle: "Avocat",                      nafCodes: ["6910Z"],          category: "Services",     active: true },
+  { slug: "comptable",     libelle: "Expert-comptable",            nafCodes: ["6920Z"],          category: "Services",     active: true },
+  { slug: "architecte",    libelle: "Architecte",                  nafCodes: ["7111Z"],          category: "Services",     active: true },
+  { slug: "agence-immo",   libelle: "Agence immobilière",          nafCodes: ["6831Z"],          category: "Services",     active: true },
+];
+
+const NAF_CODE_REGEX = /^\d{4}[A-Z]$/;
+
+export async function seedProfessions(database: Db): Promise<{ inserted: number; skipped: number }> {
+  for (const p of PROFESSIONS_SEED) {
+    for (const code of p.nafCodes) {
+      if (!NAF_CODE_REGEX.test(code)) {
+        throw new Error(`Code NAF invalide pour "${p.slug}" : "${code}" — format attendu ^\\d{4}[A-Z]$`);
+      }
+    }
+  }
+
+  const rows = await database
+    .insert(professions)
+    .values(PROFESSIONS_SEED)
+    .onConflictDoNothing({ target: professions.slug })
+    .returning({ slug: professions.slug });
+
+  return { inserted: rows.length, skipped: PROFESSIONS_SEED.length - rows.length };
+}

--- a/src/db/seeds/professions.ts
+++ b/src/db/seeds/professions.ts
@@ -6,7 +6,8 @@ export const PROFESSIONS_SEED: NewProfession[] = [
   { slug: "boulanger",     libelle: "Boulangerie-Pâtisserie",     nafCodes: ["1071C", "1071D"], category: "Alimentation", active: true },
   { slug: "restaurateur",  libelle: "Restauration traditionnelle", nafCodes: ["5610A"],          category: "Alimentation", active: true },
   { slug: "boucher",       libelle: "Boucherie-Charcuterie",      nafCodes: ["4722Z", "1013B"], category: "Alimentation", active: true },
-  { slug: "fleuriste",     libelle: "Fleuriste",                   nafCodes: ["4776Z"],          category: "Alimentation", active: true },
+
+  { slug: "fleuriste",     libelle: "Fleuriste",                   nafCodes: ["4776Z"],          category: "Commerce",     active: true },
 
   { slug: "plombier",      libelle: "Plombier-Chauffagiste",       nafCodes: ["4322A", "4322B"], category: "BTP",          active: true },
   { slug: "macon",         libelle: "Maçon",                       nafCodes: ["4399C", "4120A"], category: "BTP",          active: true },

--- a/src/db/seeds/run.ts
+++ b/src/db/seeds/run.ts
@@ -4,6 +4,9 @@ import { seedProfessions } from "./professions";
 
 async function main(): Promise<void> {
   const { inserted, skipped } = await seedProfessions(db);
+  if (skipped > 0) {
+    console.warn(`⚠️  ${skipped} profession(s) déjà présentes — nafCodes/category NE sont PAS mis à jour automatiquement.`);
+  }
   console.log(`✅ Seed professions — ${inserted} insérés, ${skipped} déjà présents`);
 }
 

--- a/src/db/seeds/run.ts
+++ b/src/db/seeds/run.ts
@@ -1,0 +1,15 @@
+import "dotenv/config";
+import { closeDb, db } from "../client";
+import { seedProfessions } from "./professions";
+
+async function main(): Promise<void> {
+  const { inserted, skipped } = await seedProfessions(db);
+  console.log(`✅ Seed professions — ${inserted} insérés, ${skipped} déjà présents`);
+}
+
+main()
+  .catch((err) => {
+    console.error("❌ Seed professions échoué :", err);
+    process.exitCode = 1;
+  })
+  .finally(() => closeDb());

--- a/src/server.ts
+++ b/src/server.ts
@@ -114,7 +114,8 @@ app.get("/api/regions", requireAuth, (_req, res) => {
 });
 
 app.get("/api/professions", requireAuth, asyncHandler(async (_req, res) => {
-  res.json(await listActiveProfessions());
+  const rows = await listActiveProfessions();
+  res.json(rows.map(({ slug, libelle, nafCodes, category }) => ({ slug, libelle, nafCodes, category })));
 }));
 
 app.get("/api/stats", requireAuth, asyncHandler(async (req, res) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -113,7 +113,7 @@ app.get("/api/regions", requireAuth, (_req, res) => {
   res.json(Object.keys(REGIONS_DEPARTEMENTS));
 });
 
-app.get("/api/professions", asyncHandler(async (_req, res) => {
+app.get("/api/professions", requireAuth, asyncHandler(async (_req, res) => {
   res.json(await listActiveProfessions());
 }));
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { auth } from "./auth";
 import { requireAuth, dashboardGuard, alreadyAuthGuard } from "./middleware/auth";
 import { validateBody, validateQuery, getValidatedQuery } from "./middleware/validate";
 import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped";
+import { listActiveProfessions } from "./db/professions";
 import { sql } from "drizzle-orm";
 import { db } from "./db/client";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
@@ -111,6 +112,10 @@ app.get("/api/health", async (_req, res) => {
 app.get("/api/regions", requireAuth, (_req, res) => {
   res.json(Object.keys(REGIONS_DEPARTEMENTS));
 });
+
+app.get("/api/professions", asyncHandler(async (_req, res) => {
+  res.json(await listActiveProfessions());
+}));
 
 app.get("/api/stats", requireAuth, asyncHandler(async (req, res) => {
   res.json(await getStats(req.user!.id));


### PR DESCRIPTION
## Contexte

Closes #44

Rend l'app multi-profession en remplaçant le hardcode NAF boulangerie/pâtisserie par une table de référence `professions` extensible, seedée avec 20 métiers populaires.

## Ce qui a été fait

Extension de la table `professions` existante avec les colonnes `slug`, `category` et `active`, accompagnée d'un seed idempotent de 20 métiers répartis en 7 catégories et d'un endpoint API protégé.

## Fichiers modifiés

- `src/db/schema.ts` — colonnes slug/category/active + index btree sur category
- `drizzle/0004_professions_extended.sql` — migration avec garde-fou si table non vide
- `src/db/professions.ts` — `listActiveProfessions()` triée par category puis libelle
- `src/db/seeds/professions.ts` — 20 métiers, validation NAF, ON CONFLICT DO NOTHING sur slug
- `src/db/seeds/run.ts` — entrypoint `npm run db:seed` avec warn si professions skippées
- `src/server.ts` — `GET /api/professions` derrière `requireAuth`, expose uniquement slug/libelle/nafCodes/category
- `package.json` — scripts `db:seed` et `db:setup` (migrate + seed en une commande)

## Points de review

- Codes NAF stockés sans point (format SIRENE `1071C`) pour matcher directement l'API INSEE.
- `onConflictDoNothing` cible `slug` uniquement — un conflit sur `libelle` (slug différent) crashe intentionnellement : c'est un fail loud sur incohérence de données.
- Migration `0004` : bloc DO $$ refuse d'exécuter si la table n'est pas vide.
- `GET /api/professions` ne retourne pas `id` ni `active` (détails internes).

## Tests

Pas de suite de tests automatisée. Vérification manuelle :
- `npm run typecheck` — passe
- `npm run db:setup` (×2 pour l'idempotence) → `GET /api/professions`