### PR TITLE
[Feature] UI sélection profession dans le dashboard (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Authentification par email/password et Google OAuth disponible sur `/api/auth/*` : signup, signin, signout avec cookie de session `HttpOnly` (secure en production) ; 50 crédits offerts automatiquement à l'inscription ([`8613e41`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8613e41))
 - `GET /api/me` — retourne la session courante de l'utilisateur connecté ; `401 Unauthorized` si non authentifié ([`8613e41`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8613e41))
 - Pages `/login` et `/signup` disponibles : formulaire email/password + bouton Google OAuth, redirection vers `/` après authentification réussie ; un utilisateur déjà connecté accédant à ces pages est automatiquement redirigé vers `/` ([`9abac3e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/9abac3e))
-- `GET /api/professions` — retourne la liste des 20 métiers actifs (`slug`, `libelle`, `nafCodes`, `category`) pré-seedés et catégorisés (Alimentation, BTP, Santé, Services, Automobile, Commerce, Beauté) ; disponibles immédiatement après `npm run db:setup` ([#71](https://github.com/alex-robert-fr/entreprise-scrapper/pull/71))
+- `GET /api/professions` — retourne la liste des 20 métiers actifs (`slug`, `libelle`, `category`) pré-seedés et catégorisés (Alimentation, BTP, Santé, Services, Automobile, Commerce, Beauté) ; disponibles immédiatement après `npm run db:setup` ([#71](https://github.com/alex-robert-fr/entreprise-scrapper/pull/71))
+- Sélection de la profession cible dans le formulaire de scrape du dashboard : dropdown groupé par catégorie, chargé dynamiquement depuis `GET /api/professions` ; `POST /api/scrape` accepte un `professionId` optionnel pour restreindre la requête SIRENE aux codes NAF de la profession choisie — comportement boulanger/pâtissier conservé si absent ([`0746e04`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/0746e04))
 
 ### Changed
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Les filtres par nom et ville du dashboard sont désormais insensibles à la casse (comportement SQLite restauré sous Postgres via `ILIKE`) ([`86aa1b4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/86aa1b4))
 - `GET /api/export` streame désormais le CSV ligne par ligne via un curseur Postgres : plus de timeout HTTP ni de saturation mémoire sur de grands volumes ([`e6909ab`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e6909ab))
+- `POST /api/scrape` : retourne `400` avec message explicite si `professionId` est inconnu ou si la profession n'a pas de codes NAF configurés, au lieu d'un fallback silencieux sur les codes boulanger/pâtissier ([`66c39a2`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/66c39a2))
 
 ### Security
 

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `src/db/scraped.ts` : `isKnownByUser(userId, siret)` remplace la déduplication globale par SIRET seul ; schéma `scraped_records` passe à une PK composite `(user_id, siret)` avec FK `user_id → user.id` et cascade delete ([#68](https://github.com/alex-robert-fr/entreprise-scrapper/pull/68))
 - `src/server.ts` : cleanup périodique de `scrapeStates` (purge toutes les 5 min les états terminés depuis > 1h, `setInterval` avec `.unref()` et désactivé en `NODE_ENV=test`) ; `finishedAt` ajouté à `ScrapeState` pour tracer la fin du scrape ; shutdown propre via `server.close()` sur SIGINT/SIGTERM ; `getScrapeState` retourne une copie de `IDLE_STATE` pour éviter toute mutation partagée ([#69](https://github.com/alex-robert-fr/entreprise-scrapper/pull/69))
 - `src/db/professions.ts` : ajout de `listActiveProfessions()` — query Drizzle filtrée sur `active = true`, ordonnée par `category` puis `libelle` ([#71](https://github.com/alex-robert-fr/entreprise-scrapper/pull/71))
+- `src/sirene.ts` : `DEFAULT_NAF_CODES` aligné sur le format DB sans point (`["1071C", "1071D"]`) ; `normalizeNafCode` appliquée systématiquement à tous les codes (default et fournis) avant la requête Lucene ; `FetchOptions` étendu avec `nafCodes?: string[]` ([`8aaa9de`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8aaa9de))
+- `src/db/professions.ts` : ajout de `getProfessionById(id: number)` ; `src/schemas/scrape.schema.ts` : `professionId` optionnel ajouté au body de scrape ; résolution des codes NAF côté serveur uniquement pour éviter la confiance client ([`96991f1`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/96991f1))
 
 ### Docs
 

--- a/src/db/professions.ts
+++ b/src/db/professions.ts
@@ -9,3 +9,8 @@ export function listActiveProfessions(): Promise<ProfessionRow[]> {
     .where(eq(professions.active, true))
     .orderBy(asc(professions.category), asc(professions.libelle));
 }
+
+export async function getProfessionById(id: number): Promise<ProfessionRow | undefined> {
+  const rows = await db.select().from(professions).where(eq(professions.id, id)).limit(1);
+  return rows[0];
+}

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -776,6 +776,13 @@
     <div class="s-section">
       <div class="s-label">Périmètre</div>
 
+      <div class="field" id="field-profession">
+        <label>Profession</label>
+        <select id="profession">
+          <option value="">— Chargement… —</option>
+        </select>
+      </div>
+
       <div class="radio-group" id="scopeToggle">
         <label id="lbl-region" class="active" onclick="setScope('region')">
           <input type="radio" name="scope" value="region" checked>
@@ -1446,6 +1453,43 @@
       counter(document.getElementById("statNotFound"), s.notFound);
     }
 
+    async function fetchProfessions() {
+      const sel = document.getElementById("profession");
+      let professions;
+      try {
+        professions = await fetch("/api/professions").then(function(r) { return r.json(); });
+      } catch {
+        sel.innerHTML = '<option value="">Erreur de chargement</option>';
+        return;
+      }
+
+      sel.innerHTML = "";
+
+      var byCategory = {};
+      professions.forEach(function(p) {
+        if (!byCategory[p.category]) byCategory[p.category] = [];
+        byCategory[p.category].push(p);
+      });
+
+      Object.keys(byCategory).sort().forEach(function(cat) {
+        var group = document.createElement("optgroup");
+        group.label = cat;
+        byCategory[cat].forEach(function(p) {
+          var o = document.createElement("option");
+          o.value = String(p.id);
+          o.dataset.slug = p.slug;
+          o.textContent = p.libelle;
+          group.appendChild(o);
+        });
+        sel.appendChild(group);
+      });
+
+      var defaultOption = sel.querySelector('option[data-slug="boulanger"]');
+      if (defaultOption) {
+        sel.value = defaultOption.value;
+      }
+    }
+
     async function fetchRegions() {
       const regions = await fetch("/api/regions").then(r => r.json());
       const sel = document.getElementById("region");
@@ -1529,6 +1573,9 @@
 
       const limitVal = parseInt(document.getElementById("limit").value);
       if (!isNaN(limitVal) && limitVal > 0) body.limit = limitVal;
+
+      const professionId = parseInt(document.getElementById("profession").value);
+      if (!isNaN(professionId) && professionId > 0) body.professionId = professionId;
 
       const res = await fetch("/api/scrape", {
         method: "POST",
@@ -1624,6 +1671,7 @@ function setExportScope(scope) {
     fetchStats();
     fetchResults();
     fetchRegions();
+    fetchProfessions();
     fetchFilterOptions();
     pollStatus();
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1455,18 +1455,27 @@
 
     async function fetchProfessions() {
       const sel = document.getElementById("profession");
-      let professions;
+      let professionList;
       try {
-        professions = await fetch("/api/professions").then(function(r) { return r.json(); });
+        professionList = await fetch("/api/professions").then(function(r) {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.json();
+        });
       } catch {
         sel.innerHTML = '<option value="">Erreur de chargement</option>';
+        return;
+      }
+
+      if (!professionList.length) {
+        sel.innerHTML = '<option value="">— Aucune profession disponible —</option>';
+        document.getElementById("btnScrape").disabled = true;
         return;
       }
 
       sel.innerHTML = "";
 
       var byCategory = {};
-      professions.forEach(function(p) {
+      professionList.forEach(function(p) {
         if (!byCategory[p.category]) byCategory[p.category] = [];
         byCategory[p.category].push(p);
       });
@@ -1487,6 +1496,8 @@
       var defaultOption = sel.querySelector('option[data-slug="boulanger"]');
       if (defaultOption) {
         sel.value = defaultOption.value;
+      } else {
+        sel.selectedIndex = 0;
       }
     }
 

--- a/src/schemas/scrape.schema.ts
+++ b/src/schemas/scrape.schema.ts
@@ -26,6 +26,7 @@ export const scrapeBodySchema = z
     departement: departementSchema.optional(),
     all: z.boolean().optional(),
     limit: z.number().int().min(1).max(10000).optional(),
+    professionId: z.number().int().positive().optional(),
   })
   .strict()
   .refine(

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import { auth } from "./auth";
 import { requireAuth, dashboardGuard, alreadyAuthGuard } from "./middleware/auth";
 import { validateBody, validateQuery, getValidatedQuery } from "./middleware/validate";
 import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped";
-import { listActiveProfessions } from "./db/professions";
+import { listActiveProfessions, getProfessionById } from "./db/professions";
 import { sql } from "drizzle-orm";
 import { db } from "./db/client";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
@@ -115,7 +115,7 @@ app.get("/api/regions", requireAuth, (_req, res) => {
 
 app.get("/api/professions", requireAuth, asyncHandler(async (_req, res) => {
   const rows = await listActiveProfessions();
-  res.json(rows.map(({ slug, libelle, nafCodes, category }) => ({ slug, libelle, nafCodes, category })));
+  res.json(rows.map(({ id, slug, libelle, nafCodes, category }) => ({ id, slug, libelle, nafCodes, category })));
 }));
 
 app.get("/api/stats", requireAuth, asyncHandler(async (req, res) => {
@@ -131,7 +131,7 @@ app.get("/api/results", requireAuth, validateQuery(resultsQuerySchema), asyncHan
   res.json(await getPaginated(req.user!.id, query.page, query.limit, pickFilters(query)));
 }));
 
-app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), (req, res) => {
+app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), asyncHandler(async (req, res) => {
   const userId = req.user!.id;
 
   if (scrapeStates.get(userId)?.status === "running") {
@@ -139,13 +139,24 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), (req, res) 
     return;
   }
 
-  const { region, departement, all, limit } = req.body as ScrapeBody;
+  const { region, departement, all, limit, professionId } = req.body as ScrapeBody;
+
+  let nafCodes: string[] | undefined;
+  if (professionId !== undefined) {
+    const profession = await getProfessionById(professionId);
+    if (!profession) {
+      res.status(400).json({ error: "Profession inconnue" });
+      return;
+    }
+    nafCodes = profession.nafCodes;
+  }
 
   const state: ScrapeState = { status: "running", progress: 0, total: 0, current: "" };
   scrapeStates.set(userId, state);
 
   (async () => {
-    const options = all ? {} : { region, departement };
+    const baseOptions = all ? {} : { region, departement };
+    const options = { ...baseOptions, ...(nafCodes ? { nafCodes } : {}) };
 
     let source: Iterable<import("./sirene").Etablissement> | AsyncIterable<import("./sirene").Etablissement>;
     if (limit !== undefined) {
@@ -176,7 +187,7 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), (req, res) 
   });
 
   res.json({ message: "Scrape lancé" });
-});
+}));
 
 app.get("/api/status", requireAuth, (req, res) => {
   res.json(getScrapeState(req.user!.id));

--- a/src/server.ts
+++ b/src/server.ts
@@ -115,7 +115,7 @@ app.get("/api/regions", requireAuth, (_req, res) => {
 
 app.get("/api/professions", requireAuth, asyncHandler(async (_req, res) => {
   const rows = await listActiveProfessions();
-  res.json(rows.map(({ id, slug, libelle, nafCodes, category }) => ({ id, slug, libelle, nafCodes, category })));
+  res.json(rows.map(({ id, slug, libelle, category }) => ({ id, slug, libelle, category })));
 }));
 
 app.get("/api/stats", requireAuth, asyncHandler(async (req, res) => {
@@ -146,6 +146,10 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), asyncHandle
     const profession = await getProfessionById(professionId);
     if (!profession) {
       res.status(400).json({ error: "Profession inconnue" });
+      return;
+    }
+    if (!profession.nafCodes.length) {
+      res.status(400).json({ error: "Cette profession n'a pas de codes NAF configurés" });
       return;
     }
     nafCodes = profession.nafCodes;

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -4,7 +4,14 @@ import "dotenv/config";
 
 const SIRENE_BASE_URL = "https://api.insee.fr/api-sirene/3.11/siret";
 
-const NAF_CODES = ["10.71C", "10.71D"];
+export const DEFAULT_NAF_CODES = ["10.71C", "10.71D"];
+
+export function normalizeNafCode(code: string): string {
+  const trimmed = code.trim().toUpperCase();
+  if (trimmed.includes(".")) return trimmed;
+  if (trimmed.length < 3) return trimmed;
+  return `${trimmed.slice(0, 2)}.${trimmed.slice(2)}`;
+}
 
 const FORMES_JURIDIQUES: Record<string, string> = {
   "1000": "EI",
@@ -64,6 +71,7 @@ export interface Etablissement {
 export interface FetchOptions {
   region?: string;
   departement?: string;
+  nafCodes?: string[];
 }
 
 // --- Helpers ---
@@ -273,8 +281,11 @@ export async function* streamEtablissements(
 
   const departements = getDepartements(options);
   const seen = new Set<string>();
+  const nafCodes = options.nafCodes?.length
+    ? options.nafCodes.map(normalizeNafCode)
+    : DEFAULT_NAF_CODES;
 
-  for (const nafCode of NAF_CODES) {
+  for (const nafCode of nafCodes) {
     for await (const etab of streamForNaf(nafCode, departements, headers)) {
       if (!seen.has(etab.siret)) {
         seen.add(etab.siret);

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -4,7 +4,7 @@ import "dotenv/config";
 
 const SIRENE_BASE_URL = "https://api.insee.fr/api-sirene/3.11/siret";
 
-export const DEFAULT_NAF_CODES = ["10.71C", "10.71D"];
+export const DEFAULT_NAF_CODES = ["1071C", "1071D"];
 
 export function normalizeNafCode(code: string): string {
   const trimmed = code.trim().toUpperCase();
@@ -281,9 +281,7 @@ export async function* streamEtablissements(
 
   const departements = getDepartements(options);
   const seen = new Set<string>();
-  const nafCodes = options.nafCodes?.length
-    ? options.nafCodes.map(normalizeNafCode)
-    : DEFAULT_NAF_CODES;
+  const nafCodes = (options.nafCodes?.length ? options.nafCodes : DEFAULT_NAF_CODES).map(normalizeNafCode);
 
   for (const nafCode of nafCodes) {
     for await (const etab of streamForNaf(nafCode, departements, headers)) {


### PR DESCRIPTION
## Contexte

Closes #45

Le dashboard scrapait uniquement les boulangeries/pâtisseries (codes NAF en dur). Cette PR permet à l'utilisateur de choisir sa profession cible avant de lancer un scrape, en s'appuyant sur la table `professions` seedée en #44.

## Changements

- **Dashboard** : dropdown "Profession" dans le formulaire de scrape, groupé par catégorie (`<optgroup>`), chargé dynamiquement depuis `GET /api/professions`, pré-sélectionne "Boulanger" par défaut (ou première option en fallback)
- **`POST /api/scrape`** : accepte un `professionId` optionnel ; résolution des codes NAF côté serveur uniquement ; retourne `400` si profession inconnue ou sans codes NAF configurés
- **`src/sirene.ts`** : `streamEtablissements` accepte `nafCodes?: string[]` ; `DEFAULT_NAF_CODES` aligné sur le format DB (`["1071C", "1071D"]`) ; `normalizeNafCode` appliquée systématiquement à tous les codes avant la requête Lucene
- **`GET /api/professions`** : retire `nafCodes` de la réponse (non nécessaire côté client)
- **`src/db/professions.ts`** : ajout de `getProfessionById(id)`

## Plan de test

- [ ] Dashboard : dropdown "Profession" visible et groupé par catégorie au chargement
- [ ] Sélectionner "Boulanger" → comportement identique à l'actuel (codes NAF boulanger/pâtissier)
- [ ] Sélectionner une autre profession → requête SIRENE filtrée sur ses codes NAF
- [ ] `POST /api/scrape` sans `professionId` → fallback sur codes par défaut, pas d'erreur
- [ ] `POST /api/scrape` avec `professionId` inexistant → `400` avec message clair
- [ ] `GET /api/professions` ne retourne plus `nafCodes`
- [ ] Table `professions` vide : bouton "Lancer le scrape" désactivé, message dans le dropdown