### PR TITLE
[Refactor] Centraliser fetchWithRetry dans src/http.ts (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Les filtres par nom et ville du dashboard sont désormais insensibles à la casse (comportement SQLite restauré sous Postgres via `ILIKE`) ([`86aa1b4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/86aa1b4))
 - `GET /api/export` streame désormais le CSV ligne par ligne via un curseur Postgres : plus de timeout HTTP ni de saturation mémoire sur de grands volumes ([`e6909ab`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e6909ab))
 - `POST /api/scrape` : retourne `400` avec message explicite si `professionId` est inconnu ou si la profession n'a pas de codes NAF configurés, au lieu d'un fallback silencieux sur les codes boulanger/pâtissier ([`66c39a2`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/66c39a2))
+- Les erreurs 401 et 403 de l'API Google Maps lèvent désormais une exception explicite au lieu de retourner silencieusement `null`, rendant immédiatement visible tout problème de clé API invalide ou quota dépassé ([`d90a487`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/d90a487))
 
 ### Security
 

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `src/db/professions.ts` : ajout de `listActiveProfessions()` — query Drizzle filtrée sur `active = true`, ordonnée par `category` puis `libelle` ([#71](https://github.com/alex-robert-fr/entreprise-scrapper/pull/71))
 - `src/sirene.ts` : `DEFAULT_NAF_CODES` aligné sur le format DB sans point (`["1071C", "1071D"]`) ; `normalizeNafCode` appliquée systématiquement à tous les codes (default et fournis) avant la requête Lucene ; `FetchOptions` étendu avec `nafCodes?: string[]` ([`8aaa9de`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8aaa9de))
 - `src/db/professions.ts` : ajout de `getProfessionById(id: number)` ; `src/schemas/scrape.schema.ts` : `professionId` optionnel ajouté au body de scrape ; résolution des codes NAF côté serveur uniquement pour éviter la confiance client ([`96991f1`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/96991f1))
+- Centralisation de `fetchWithRetry` dans `src/http.ts` : suppression des 3 implémentations dupliquées dans `sirene.ts`, `googleMaps.ts` et `annuaireEntreprises.ts` ; throw explicite après `MAX_RETRIES` tentatives retryables, `sleep()` dédupliquée ([`7215f1b`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/7215f1b))
 
 ### Docs
 

--- a/src/annuaireEntreprises.ts
+++ b/src/annuaireEntreprises.ts
@@ -1,7 +1,6 @@
+import { fetchWithRetry } from "./http";
+
 const BASE_URL = "https://recherche-entreprises.api.gouv.fr/search";
-const MAX_RETRIES = 3;
-const RETRY_BASE_DELAY = 1000;
-const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
 
 interface Dirigeant {
   nom: string;
@@ -11,35 +10,6 @@ interface Dirigeant {
 
 interface SearchResult {
   results?: Array<{ dirigeants?: Dirigeant[] }>;
-}
-
-async function fetchWithRetry(url: string): Promise<Response> {
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    try {
-      const response = await fetch(url);
-      if (response.ok || !RETRYABLE_STATUS.has(response.status)) {
-        return response;
-      }
-      if (attempt < MAX_RETRIES - 1) {
-        const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
-        console.warn(
-          `Annuaire Entreprises — HTTP ${response.status}, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`
-        );
-        await new Promise((r) => setTimeout(r, delay));
-      }
-    } catch (err) {
-      if (attempt < MAX_RETRIES - 1) {
-        const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
-        console.warn(
-          `Annuaire Entreprises — erreur réseau, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`
-        );
-        await new Promise((r) => setTimeout(r, delay));
-      } else {
-        throw err;
-      }
-    }
-  }
-  return fetch(url);
 }
 
 function formatDirigeants(dirigeants: Dirigeant[]): string {

--- a/src/googleMaps.ts
+++ b/src/googleMaps.ts
@@ -1,42 +1,7 @@
+import { fetchWithRetry } from "./http";
+
 // Places API (New) — https://developers.google.com/maps/documentation/places/web-service/text-search
 const PLACES_NEW_BASE_URL = "https://places.googleapis.com/v1/places";
-const MAX_RETRIES = 3;
-const RETRY_BASE_DELAY = 1000;
-const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
-
-// --- Retry HTTP ---
-
-async function fetchWithRetry(
-  url: string,
-  init?: RequestInit
-): Promise<Response> {
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    try {
-      const response = await fetch(url, init);
-      if (response.ok || !RETRYABLE_STATUS.has(response.status)) {
-        return response;
-      }
-      if (attempt < MAX_RETRIES - 1) {
-        const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
-        console.warn(
-          `Google Maps — HTTP ${response.status}, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`
-        );
-        await new Promise((r) => setTimeout(r, delay));
-      }
-    } catch (err) {
-      if (attempt < MAX_RETRIES - 1) {
-        const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
-        console.warn(
-          `Google Maps — erreur réseau, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`
-        );
-        await new Promise((r) => setTimeout(r, delay));
-      } else {
-        throw err;
-      }
-    }
-  }
-  return fetch(url, init);
-}
 
 // --- Types Places API (New) ---
 

--- a/src/googleMaps.ts
+++ b/src/googleMaps.ts
@@ -31,6 +31,9 @@ async function searchPlace(
     body: JSON.stringify({ textQuery: `${nom} ${ville}` }),
   });
 
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(`Google Maps — clé API invalide ou quota dépassé (HTTP ${response.status})`);
+  }
   if (!response.ok) {
     console.warn(`Google Maps Text Search — HTTP ${response.status}`);
     return null;
@@ -47,7 +50,7 @@ async function getPhoneNumber(
   apiKey: string
 ): Promise<string | null> {
   const response = await fetchWithRetry(
-    `${PLACES_NEW_BASE_URL}/${encodeURIComponent(placeId)}`,
+    `${PLACES_NEW_BASE_URL}/${placeId}`,
     {
       headers: {
         "X-Goog-Api-Key": apiKey,
@@ -56,6 +59,9 @@ async function getPhoneNumber(
     }
   );
 
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(`Google Maps — clé API invalide ou quota dépassé (HTTP ${response.status})`);
+  }
   if (!response.ok) {
     console.warn(`Google Maps Place Details — HTTP ${response.status}`);
     return null;

--- a/src/http.ts
+++ b/src/http.ts
@@ -2,27 +2,30 @@ const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 1000;
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Retente sur les statuts retryables (429, 5xx). Retourne la Response sans la valider — l'appelant doit vérifier response.ok. */
 export async function fetchWithRetry(
   url: string,
   init?: RequestInit
 ): Promise<Response> {
+  let lastResponse: Response | undefined;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
       const response = await fetch(url, init);
+      lastResponse = response;
       if (response.ok || !RETRYABLE_STATUSES.has(response.status)) {
         return response;
       }
       if (attempt < MAX_RETRIES - 1) {
-        await new Promise((r) =>
-          setTimeout(r, RETRY_BASE_DELAY_MS * Math.pow(2, attempt))
-        );
+        await sleep(RETRY_BASE_DELAY_MS * Math.pow(2, attempt));
       }
     } catch (err) {
       if (attempt >= MAX_RETRIES - 1) throw err;
-      await new Promise((r) =>
-        setTimeout(r, RETRY_BASE_DELAY_MS * Math.pow(2, attempt))
-      );
+      await sleep(RETRY_BASE_DELAY_MS * Math.pow(2, attempt));
     }
   }
-  return fetch(url, init);
+  throw new Error(
+    `fetchWithRetry: échec après ${MAX_RETRIES} tentatives — HTTP ${lastResponse?.status ?? "réseau"}`
+  );
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,28 @@
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 1000;
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+export async function fetchWithRetry(
+  url: string,
+  init?: RequestInit
+): Promise<Response> {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, init);
+      if (response.ok || !RETRYABLE_STATUSES.has(response.status)) {
+        return response;
+      }
+      if (attempt < MAX_RETRIES - 1) {
+        await new Promise((r) =>
+          setTimeout(r, RETRY_BASE_DELAY_MS * Math.pow(2, attempt))
+        );
+      }
+    } catch (err) {
+      if (attempt >= MAX_RETRIES - 1) throw err;
+      await new Promise((r) =>
+        setTimeout(r, RETRY_BASE_DELAY_MS * Math.pow(2, attempt))
+      );
+    }
+  }
+  return fetch(url, init);
+}

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { fetchWithRetry } from "./http";
 
 // --- Constantes ---
 
@@ -25,8 +26,6 @@ const FORMES_JURIDIQUES: Record<string, string> = {
 const TRANCHE_MIN = "11";
 const TRANCHE_MAX = "53";
 const PAGE_SIZE = 100;
-const MAX_RETRIES = 3;
-const RETRY_BASE_DELAY = 1000;
 
 export const REGIONS_DEPARTEMENTS: Record<string, string[]> = {
   "auvergne-rhone-alpes": [
@@ -132,36 +131,6 @@ function buildUrl(query: string, curseur: string): string {
   return `${SIRENE_BASE_URL}?q=${encoded}&nombre=${PAGE_SIZE}&curseur=${encodeURIComponent(curseur)}`;
 }
 
-const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
-
-async function fetchWithRetry(
-  url: string,
-  headers: Record<string, string>
-): Promise<Response> {
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    try {
-      const response = await fetch(url, { headers });
-      if (response.ok || !RETRYABLE_STATUS.has(response.status)) {
-        return response;
-      }
-      if (attempt < MAX_RETRIES - 1) {
-        const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
-        console.warn(`SIRENE — HTTP ${response.status}, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`);
-        await new Promise((r) => setTimeout(r, delay));
-      }
-    } catch (err) {
-      if (attempt < MAX_RETRIES - 1) {
-        const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
-        console.warn(`SIRENE — erreur réseau, retry ${attempt + 1}/${MAX_RETRIES} dans ${delay}ms`);
-        await new Promise((r) => setTimeout(r, delay));
-      } else {
-        throw err;
-      }
-    }
-  }
-  return fetch(url, { headers });
-}
-
 // --- Mapping ---
 
 interface SireneAdresse {
@@ -244,7 +213,7 @@ async function* streamForNaf(
 
   while (true) {
     const url = buildUrl(query, curseur);
-    const response = await fetchWithRetry(url, headers);
+    const response = await fetchWithRetry(url, { headers });
 
     if (response.status === 404) break;
 

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -249,6 +249,7 @@ export async function* streamEtablissements(
   };
 
   const departements = getDepartements(options);
+  // Déduplique les SIRETs présents dans plusieurs passes NAF — croît en O(n) en mémoire sur --all
   const seen = new Set<string>();
   const nafCodes = (options.nafCodes?.length ? options.nafCodes : DEFAULT_NAF_CODES).map(normalizeNafCode);
 


### PR DESCRIPTION
## Contexte

Centralise `fetchWithRetry` dans `src/http.ts` pour éliminer la duplication de logique de retry présente dans `sirene.ts`, `googleMaps.ts` et `annuaireEntreprises.ts`.

Closes #46

## Changements

- Nouveau module `src/http.ts` : `fetchWithRetry(url, init?)` avec `MAX_RETRIES=3`, backoff exponentiel et throw explicite après épuisement des tentatives
- `sirene.ts`, `googleMaps.ts`, `annuaireEntreprises.ts` : suppression des implémentations locales, import depuis `./http`
- Correction suite review : les erreurs 401/403 Google Maps lèvent désormais une exception explicite au lieu de retourner `null` silencieusement

## Test plan

- [ ] `npx tsc --noEmit` passe sans erreur
- [ ] Aucune déclaration locale `fetchWithRetry` dans `src/` hors `http.ts`
- [ ] Les trois fichiers importent depuis `./http`