### PR TITLE
[Chore] Fix staging Railway : migrations auto au boot + audit env vars (#77)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -103,14 +103,18 @@ Vérifier :
 
 - Vérifier que `/api/health` répond localement : `curl http://localhost:3000/api/health`
 - Ajuster `healthcheckTimeout` dans `railway.json` si le démarrage est long
-- Le healthcheck interroge la DB via `getStats()` — si Postgres n'est pas joignable, le check renvoie 503
+- Si Postgres n'est pas joignable, le check renvoie 503 — vérifier `DATABASE_URL` dans les variables Railway
+- Si `BETTER_AUTH_SECRET` est absent, le process crash avant d'écouter → vérifier les variables d'env
 
-### Appliquer les migrations en prod
+### Migrations en prod
 
-Railway ne joue pas automatiquement `drizzle-kit migrate`. Deux options :
+Les migrations Drizzle et le seed des professions sont **automatiques au boot** (`src/db/migrate.ts` + `src/db/seeds/professions.ts` appelés dans `src/server.ts` avant `app.listen`). Aucune action manuelle requise.
 
-- Ajouter `npm run db:migrate && npm run start:prod` dans la `startCommand` de `railway.json`
-- Ou exécuter manuellement via `railway run npm run db:migrate` après chaque nouvelle migration
+Si le schéma de la DB staging a été initialisé via `drizzle-kit push` (sans table `__drizzle_migrations`), bootstrapper une fois manuellement :
+
+```bash
+railway run npm run db:migrate
+```
 
 ---
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -64,10 +64,11 @@ Railway émet automatiquement le certificat Let's Encrypt une fois le DNS propag
 
 Dashboard Railway → service web → **Variables** → ajouter :
 
+> **⚠️ Ne pas définir `PORT` manuellement** — Railway l'injecte automatiquement. Le définir crée un conflit et rend l'app inaccessible.
+
 | Variable | Valeur | Notes |
 |----------|--------|-------|
 | `NODE_ENV` | `production` | |
-| `PORT` | (laisser Railway l'injecter) | Railway injecte `PORT` automatiquement |
 | `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | référence Railway |
 | `SIRENE_TOKEN` | valeur réelle | |
 | `GOOGLE_MAPS_API_KEY` | valeur réelle | |
@@ -110,7 +111,9 @@ Vérifier :
 
 Les migrations Drizzle et le seed des professions sont **automatiques au boot** (`src/db/migrate.ts` + `src/db/seeds/professions.ts` appelés dans `src/server.ts` avant `app.listen`). Aucune action manuelle requise.
 
-Si le schéma de la DB staging a été initialisé via `drizzle-kit push` (sans table `__drizzle_migrations`), bootstrapper une fois manuellement :
+> **⚠️ Scale horizontal** : le seed est idempotent (`onConflictDoNothing`) mais pas conçu pour être exécuté en parallèle sur plusieurs réplicas simultanés. Ne pas scaler à >1 réplica sans extraire migrations et seed dans un job de démarrage dédié (Railway `Pre-deploy Command`).
+
+Si le schéma de la DB staging a été initialisé via `drizzle-kit push` (sans table `__drizzle_migrations`), bootstrapper une fois manuellement via le **CLI drizzle-kit** (outil dev uniquement — pas le même mécanisme que le boot automatique) :
 
 ```bash
 railway run npm run db:migrate

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Chore
+
+- `src/db/migrate.ts` : runner de migration programmatique utilisant `drizzle-orm/postgres-js/migrator` — remplace le recours au CLI `drizzle-kit` (devDependency absent en prod) ; connexion dédiée `max: 1`, fermée après usage ([`4970442`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/4970442))
+- `src/server.ts` : migrations Drizzle et seed professions lancés automatiquement au boot avant `app.listen` ; `process.exit(1)` si échec ; `cleanupTimer` déplacé après validation boot ; shutdown propre avec `closeDb()` sur SIGTERM/SIGINT ([`31b876d`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/31b876d), [`ea2422d`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/ea2422d))
+
+### Docs
+
+- `DEPLOYMENT.md` : migrations en prod documentées comme automatiques au boot ; avertissement scale horizontal (>1 réplica) ; `PORT` à ne pas définir manuellement sur Railway ; distinction CLI `drizzle-kit` vs runner runtime ([`f909258`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/f909258))
+
 ### Refactor
 
 - Port de `dedup.ts` (SQLite/better-sqlite3) vers `src/db/` avec Drizzle ORM + postgres-js : `scraped.ts`, `phoneCache.ts`, `client.ts`, `index.ts`, `schema.ts` ([`33639a0`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/33639a0), [`e30efd0`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e30efd0), [`8b7a160`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8b7a160), [`9b0b101`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/9b0b101))

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,0 +1,25 @@
+import "dotenv/config";
+import path from "path";
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+
+const MIGRATIONS_FOLDER = path.resolve(process.cwd(), "drizzle");
+
+export async function runMigrations(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL manquante — impossible d'appliquer les migrations");
+  }
+
+  const client = postgres(databaseUrl, { max: 1, prepare: false });
+  const db = drizzle(client);
+
+  console.log("[migrate] application des migrations...");
+  try {
+    await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+    console.log("[migrate] done");
+  } finally {
+    await client.end({ timeout: 5 });
+  }
+}

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -4,7 +4,7 @@ import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 
-const MIGRATIONS_FOLDER = path.resolve(process.cwd(), "drizzle");
+const MIGRATIONS_FOLDER = path.resolve(__dirname, "../../drizzle");
 
 export async function runMigrations(): Promise<void> {
   const databaseUrl = process.env.DATABASE_URL;
@@ -12,6 +12,7 @@ export async function runMigrations(): Promise<void> {
     throw new Error("DATABASE_URL manquante — impossible d'appliquer les migrations");
   }
 
+  // Connexion dédiée et éphémère — ne pas réutiliser le pool applicatif (db/client.ts)
   const client = postgres(databaseUrl, { max: 1, prepare: false });
   const db = drizzle(client);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,8 @@
 import "dotenv/config";
 import path from "path";
 import express, { type Request, type Response, type NextFunction, type RequestHandler } from "express";
+import { runMigrations } from "./db/migrate";
+import { seedProfessions } from "./db/seeds/professions";
 import { toNodeHandler, fromNodeHeaders } from "better-auth/node";
 import { auth } from "./auth";
 import { requireAuth, dashboardGuard, alreadyAuthGuard } from "./middleware/auth";
@@ -250,13 +252,24 @@ app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
   res.status(500).json({ error: "Erreur serveur" });
 });
 
-const server = app.listen(PORT, () => {
-  console.log(`Dashboard disponible sur http://localhost:${PORT}`);
-});
+(async () => {
+  try {
+    await runMigrations();
+    const { inserted, skipped } = await seedProfessions(db);
+    console.log(`[seed] professions: ${inserted} insérées, ${skipped} déjà présentes`);
+  } catch (err) {
+    console.error("[boot] échec migrations/seed :", err);
+    process.exit(1);
+  }
 
-function shutdown() {
-  if (cleanupTimer) clearInterval(cleanupTimer);
-  server.close(() => process.exit(0));
-}
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
+  const server = app.listen(PORT, () => {
+    console.log(`Dashboard disponible sur http://localhost:${PORT}`);
+  });
+
+  function shutdown() {
+    if (cleanupTimer) clearInterval(cleanupTimer);
+    server.close(() => process.exit(0));
+  }
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+})();

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import { validateBody, validateQuery, getValidatedQuery } from "./middleware/val
 import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped";
 import { listActiveProfessions, getProfessionById } from "./db/professions";
 import { sql } from "drizzle-orm";
-import { db } from "./db/client";
+import { db, closeDb } from "./db/client";
 import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
 import { runPipeline } from "./pipeline";
 import {
@@ -62,9 +62,7 @@ function cleanupFinishedStates(now: number = Date.now()) {
   }
 }
 
-const cleanupTimer =
-  process.env.NODE_ENV === "test" ? null : setInterval(cleanupFinishedStates, CLEANUP_INTERVAL_MS);
-cleanupTimer?.unref();
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
 // Better Auth doit lire le body brut — monté AVANT express.json()
 app.all("/api/auth/*", toNodeHandler(auth));
@@ -262,13 +260,19 @@ app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
     process.exit(1);
   }
 
+  cleanupTimer = process.env.NODE_ENV === "test" ? null : setInterval(cleanupFinishedStates, CLEANUP_INTERVAL_MS);
+  cleanupTimer?.unref();
+
   const server = app.listen(PORT, () => {
     console.log(`Dashboard disponible sur http://localhost:${PORT}`);
   });
 
   function shutdown() {
     if (cleanupTimer) clearInterval(cleanupTimer);
-    server.close(() => process.exit(0));
+    server.close(async () => {
+      await closeDb().catch(() => {});
+      process.exit(0);
+    });
   }
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);


### PR DESCRIPTION
## Contexte

Closes #77

Le staging Railway ne démarre pas — healthcheck `/api/health` échoue systématiquement (`service unavailable` x4). Causes identifiées : migrations Drizzle jamais jouées (tables absentes), `drizzle-kit` inutilisable en prod (devDependency), et variables d'env potentiellement manquantes.

## Changements

- `src/db/migrate.ts` (créé) : runner de migration programmatique via `drizzle-orm/postgres-js/migrator` — connexion dédiée `max: 1`, fermée après usage, chemin ancré sur `__dirname` (stable quel que soit le `cwd` au lancement)
- `src/server.ts` : migrations + seed professions lancés au boot avant `app.listen` ; `process.exit(1)` si échec ; `cleanupTimer` déplacé après validation boot ; shutdown propre avec `closeDb()` sur SIGTERM/SIGINT
- `DEPLOYMENT.md` : migrations documentées comme automatiques ; avertissement `PORT` Railway ; avertissement scale horizontal ; distinction CLI `drizzle-kit` vs runner runtime

## Test plan

- [x] Vérifier les variables d'env sur le service staging Railway : `DATABASE_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `SIRENE_TOKEN`, `GOOGLE_MAPS_API_KEY`
- [x] Tester en local sur DB vide : `docker compose up -d db` → wipe → `npm run build && npm run start:prod` → logs `[migrate] done` + `[seed] professions: ...` + healthcheck 200
- [x] Push → vérifier healthcheck vert sur staging Railway
- [x] Re-deploy → vérifier idempotence (migrations non rejouées, seed skippé)