### PR TITLE
[Fix] Migrer vers ESM (NodeNext) — compatibilité better-auth (#81)

### DIFF
--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Chore
 
+- Migration vers ESM (`"type": "module"` + `tsconfig NodeNext`) : 15 fichiers d'imports suffixés `.js`, `__dirname` remplacé par `fileURLToPath` — résout `ERR_REQUIRE_ESM` au démarrage causé par `better-auth/node` (ESM-only) ([`c522acd`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/c522acd))
 - `src/db/migrate.ts` : runner de migration programmatique utilisant `drizzle-orm/postgres-js/migrator` — remplace le recours au CLI `drizzle-kit` (devDependency absent en prod) ; connexion dédiée `max: 1`, fermée après usage ([`4970442`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/4970442))
 - `src/server.ts` : migrations Drizzle et seed professions lancés automatiquement au boot avant `app.listen` ; `process.exit(1)` si échec ; `cleanupTimer` déplacé après validation boot ; shutdown propre avec `closeDb()` sur SIGTERM/SIGINT ([`31b876d`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/31b876d), [`ea2422d`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/ea2422d))
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "entreprise-scrapper",
+  "type": "module",
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "server": "ts-node src/server.ts",
+    "server": "node --loader ts-node/esm src/server.ts",
     "start:prod": "node dist/server.js",
     "build": "tsc && rm -rf dist/public dist/views && cp -r src/public dist/public && cp -r src/views dist/views",
     "typecheck": "tsc --noEmit",
@@ -11,7 +12,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "db:seed": "ts-node src/db/seeds/run.ts",
+    "db:seed": "node --loader ts-node/esm src/db/seeds/run.ts",
     "db:setup": "npm run db:migrate && npm run db:seed"
   },
   "dependencies": {

--- a/src/annuaireEntreprises.ts
+++ b/src/annuaireEntreprises.ts
@@ -1,4 +1,4 @@
-import { fetchWithRetry } from "./http";
+import { fetchWithRetry } from "./http.js";
 
 const BASE_URL = "https://recherche-entreprises.api.gouv.fr/search";
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,8 +1,8 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { admin } from "better-auth/plugins";
-import { db } from "./db/client";
-import { user, session, account, verification, credits } from "./db/schema";
+import { db } from "./db/client.js";
+import { user, session, account, verification, credits } from "./db/schema.js";
 
 const secret = process.env.BETTER_AUTH_SECRET;
 if (!secret) {

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
-import * as schema from "./schema";
+import * as schema from "./schema.js";
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,3 +1,3 @@
-export * from "./schema";
-export * from "./scraped";
-export * from "./professions";
+export * from "./schema.js";
+export * from "./scraped.js";
+export * from "./professions.js";

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,9 +1,11 @@
 import "dotenv/config";
 import path from "path";
+import { fileURLToPath } from "url";
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MIGRATIONS_FOLDER = path.resolve(__dirname, "../../drizzle");
 
 export async function runMigrations(): Promise<void> {

--- a/src/db/professions.ts
+++ b/src/db/professions.ts
@@ -1,6 +1,6 @@
 import { asc, eq } from "drizzle-orm";
-import { db } from "./client";
-import { professions, type ProfessionRow } from "./schema";
+import { db } from "./client.js";
+import { professions, type ProfessionRow } from "./schema.js";
 
 export function listActiveProfessions(): Promise<ProfessionRow[]> {
   return db

--- a/src/db/scraped.ts
+++ b/src/db/scraped.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, ilike, inArray, like, sql, type SQL } from "drizzle-orm";
-import { db, pgClient } from "./client";
-import { scrapedRecords, excluded } from "./schema";
-import { phoneTypeCondition } from "../phoneUtils";
+import { db, pgClient } from "./client.js";
+import { scrapedRecords, excluded } from "./schema.js";
+import { phoneTypeCondition } from "../phoneUtils.js";
 // Les filtres consommes par la couche DB — formes miroir du schema Zod
 // cote HTTP, mais avec "sourceFilter" comme nom interne (le param HTTP
 // s'appelle "source").

--- a/src/db/seeds/professions.ts
+++ b/src/db/seeds/professions.ts
@@ -1,5 +1,5 @@
-import type { Db } from "../client";
-import { professions, type NewProfession } from "../schema";
+import type { Db } from "../client.js";
+import { professions, type NewProfession } from "../schema.js";
 
 // Codes NAF stockés sans point pour matcher directement SIRENE (ex: "1071C", pas "10.71C").
 export const PROFESSIONS_SEED: NewProfession[] = [

--- a/src/db/seeds/run.ts
+++ b/src/db/seeds/run.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
-import { closeDb, db } from "../client";
-import { seedProfessions } from "./professions";
+import { closeDb, db } from "../client.js";
+import { seedProfessions } from "./professions.js";
 
 async function main(): Promise<void> {
   const { inserted, skipped } = await seedProfessions(db);

--- a/src/googleMaps.ts
+++ b/src/googleMaps.ts
@@ -1,4 +1,4 @@
-import { fetchWithRetry } from "./http";
+import { fetchWithRetry } from "./http.js";
 
 // Places API (New) — https://developers.google.com/maps/documentation/places/web-service/text-search
 const PLACES_NEW_BASE_URL = "https://places.googleapis.com/v1/places";

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from "express";
 import { fromNodeHeaders } from "better-auth/node";
-import { auth } from "../auth";
+import { auth } from "../auth.js";
 
 export type UserRole = "user" | "admin";
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,7 +1,7 @@
-import { Etablissement } from "./sirene";
-import { isKnownByUser, insert, ScrapedRecord } from "./db/scraped";
-import { findPhoneGoogle } from "./googleMaps";
-import { fetchDirigeants } from "./annuaireEntreprises";
+import { Etablissement } from "./sirene.js";
+import { isKnownByUser, insert, ScrapedRecord } from "./db/scraped.js";
+import { findPhoneGoogle } from "./googleMaps.js";
+import { fetchDirigeants } from "./annuaireEntreprises.js";
 
 export interface PipelineResult {
   newCount: number;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,4 +1,4 @@
-export { scrapeBodySchema, type ScrapeBody } from "./scrape.schema";
+export { scrapeBodySchema, type ScrapeBody } from "./scrape.schema.js";
 export {
   resultFiltersSchema,
   resultsQuerySchema,
@@ -6,5 +6,5 @@ export {
   type ResultFiltersInput,
   type ResultsQuery,
   type ExportQuery,
-} from "./filters.schema";
-export { polarWebhookSchema, type PolarWebhook } from "./billing.schema";
+} from "./filters.schema.js";
+export { polarWebhookSchema, type PolarWebhook } from "./billing.schema.js";

--- a/src/schemas/scrape.schema.ts
+++ b/src/schemas/scrape.schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { REGIONS_DEPARTEMENTS, normalizeRegion } from "../sirene";
+import { REGIONS_DEPARTEMENTS, normalizeRegion } from "../sirene.js";
 
 const VALID_REGION_KEYS = new Set(Object.keys(REGIONS_DEPARTEMENTS));
 const VALID_DEPARTEMENTS = new Set(Object.values(REGIONS_DEPARTEMENTS).flat());

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,18 +1,21 @@
 import "dotenv/config";
 import path from "path";
+import { fileURLToPath } from "url";
 import express, { type Request, type Response, type NextFunction, type RequestHandler } from "express";
-import { runMigrations } from "./db/migrate";
-import { seedProfessions } from "./db/seeds/professions";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { runMigrations } from "./db/migrate.js";
+import { seedProfessions } from "./db/seeds/professions.js";
 import { toNodeHandler, fromNodeHeaders } from "better-auth/node";
-import { auth } from "./auth";
-import { requireAuth, dashboardGuard, alreadyAuthGuard } from "./middleware/auth";
-import { validateBody, validateQuery, getValidatedQuery } from "./middleware/validate";
-import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped";
-import { listActiveProfessions, getProfessionById } from "./db/professions";
+import { auth } from "./auth.js";
+import { requireAuth, dashboardGuard, alreadyAuthGuard } from "./middleware/auth.js";
+import { validateBody, validateQuery, getValidatedQuery } from "./middleware/validate.js";
+import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped.js";
+import { listActiveProfessions, getProfessionById } from "./db/professions.js";
 import { sql } from "drizzle-orm";
-import { db, closeDb } from "./db/client";
-import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene";
-import { runPipeline } from "./pipeline";
+import { db, closeDb } from "./db/client.js";
+import { fetchEtablissements, streamEtablissements, REGIONS_DEPARTEMENTS } from "./sirene.js";
+import { runPipeline } from "./pipeline.js";
 import {
   scrapeBodySchema,
   resultsQuerySchema,
@@ -20,7 +23,7 @@ import {
   type ScrapeBody,
   type ResultsQuery,
   type ExportQuery,
-} from "./schemas";
+} from "./schemas/index.js";
 
 const asyncHandler =
   (fn: (req: Request, res: Response) => Promise<unknown>): RequestHandler =>
@@ -162,7 +165,7 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), asyncHandle
     const baseOptions = all ? {} : { region, departement };
     const options = { ...baseOptions, ...(nafCodes ? { nafCodes } : {}) };
 
-    let source: Iterable<import("./sirene").Etablissement> | AsyncIterable<import("./sirene").Etablissement>;
+    let source: Iterable<import("./sirene.js").Etablissement> | AsyncIterable<import("./sirene.js").Etablissement>;
     if (limit !== undefined) {
       state.total = limit;
       source = streamEtablissements(options);

--- a/src/sirene.ts
+++ b/src/sirene.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { fetchWithRetry } from "./http";
+import { fetchWithRetry } from "./http.js";
 
 // --- Constantes ---
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Contexte

Closes #81

`better-auth/node` est un ES Module pur (`.mjs`). Le projet compilait en CommonJS (`"module": "commonjs"`), ce qui provoque `ERR_REQUIRE_ESM` au démarrage sur Railway — même avec Node 22.11.0, car le support natif de `require(ESM)` n'est stable qu'à partir de Node 22.12.0.

## Changements

- `tsconfig.json` : `"module": "NodeNext"` + `"moduleResolution": "NodeNext"`
- `package.json` : `"type": "module"` + scripts dev mis à jour (`ts-node/esm`)
- 15 fichiers : imports relatifs suffixés `.js` (requis en NodeNext)
- `src/server.ts` + `src/db/migrate.ts` : `__dirname` remplacé par `fileURLToPath(import.meta.url)`

## Test plan

- [ ] `npm run build` → 0 erreur TypeScript
- [ ] Merger sur `develop` → Railway redéploie → `ERR_REQUIRE_ESM` disparu des logs
- [ ] Healthcheck Railway passe (vert)