### PR TITLE
[Feature] Système de crédits — décrément par fiche affichée (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Les 50 crédits offerts à l'inscription sont désormais tracés dans l'historique et visibles via `GET /api/credits` (transaction `signup_bonus`) ([`12a7fbf`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/12a7fbf))
+- Chaque fiche insérée lors d'un scrape consomme automatiquement 1 crédit ; le pipeline s'arrête si le solde atteint 0 et `GET /api/status` retourne un message explicite ([`f371473`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/f371473))
+- `GET /api/credits` — retourne le solde actuel et les 20 dernières transactions (type, montant, date) ([`8c561d0`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8c561d0))
 - Authentification par email/password et Google OAuth disponible sur `/api/auth/*` : signup, signin, signout avec cookie de session `HttpOnly` (secure en production) ; 50 crédits offerts automatiquement à l'inscription ([`8613e41`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8613e41))
 - `GET /api/me` — retourne la session courante de l'utilisateur connecté ; `401 Unauthorized` si non authentifié ([`8613e41`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8613e41))
 - Pages `/login` et `/signup` disponibles : formulaire email/password + bouton Google OAuth, redirection vers `/` après authentification réussie ; un utilisateur déjà connecté accédant à ces pages est automatiquement redirigé vers `/` ([`9abac3e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/9abac3e))
@@ -22,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- L'insertion d'une fiche et le décrément du crédit s'effectuent dans la même transaction Postgres : un crash ne peut ni débiter sans insérer, ni insérer sans débiter ([`bc3deb9`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/bc3deb9))
 - Les filtres par nom et ville du dashboard sont désormais insensibles à la casse (comportement SQLite restauré sous Postgres via `ILIKE`) ([`86aa1b4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/86aa1b4))
 - `GET /api/export` streame désormais le CSV ligne par ligne via un curseur Postgres : plus de timeout HTTP ni de saturation mémoire sur de grands volumes ([`e6909ab`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e6909ab))
 - `POST /api/scrape` : retourne `400` avec message explicite si `professionId` est inconnu ou si la profession n'a pas de codes NAF configurés, au lieu d'un fallback silencieux sur les codes boulanger/pâtissier ([`66c39a2`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/66c39a2))

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactor
+
+- `src/auth.ts` : hook signup délégué à `grantSignupBonus(tx)` — idempotence basée sur la présence d'une transaction `signup_bonus` plutôt que la ligne `credits` (résistant aux crashs partiels) ([`6f79a24`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/6f79a24))
+- `src/db/scraped.ts` : nouvelle fonction `insertWithCreditConsume` — transaction atomique insert + `consumeOne` avec guard `userId mismatch` en entrée ([`bc3deb9`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/bc3deb9))
+
 ### Chore
 
+- Nouveau module `src/db/credits.ts` : services `getBalance`, `getRecentTransactions`, `grantSignupBonus`, `consumeOne`, `adminGrant` + `InsufficientCreditsError` ([`12a7fbf`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/12a7fbf))
+- Migration `0006_credit_tx_signup_bonus.sql` : ajout de `signup_bonus` dans le CHECK `credit_tx_type_check` de `credit_transactions` ([`eef50cd`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/eef50cd))
 - Migration vers ESM (`"type": "module"` + `tsconfig NodeNext`) : 15 fichiers d'imports suffixés `.js`, `__dirname` remplacé par `fileURLToPath` — résout `ERR_REQUIRE_ESM` au démarrage causé par `better-auth/node` (ESM-only) ([`c522acd`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/c522acd))
 - `src/db/migrate.ts` : runner de migration programmatique utilisant `drizzle-orm/postgres-js/migrator` — remplace le recours au CLI `drizzle-kit` (devDependency absent en prod) ; connexion dédiée `max: 1`, fermée après usage ([`4970442`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/4970442))
 - `src/server.ts` : migrations Drizzle et seed professions lancés automatiquement au boot avant `app.listen` ; `process.exit(1)` si échec ; `cleanupTimer` déplacé après validation boot ; shutdown propre avec `closeDb()` sur SIGTERM/SIGINT ([`31b876d`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/31b876d), [`ea2422d`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/ea2422d))

--- a/drizzle/0005_scraped_profession_credits_check.sql
+++ b/drizzle/0005_scraped_profession_credits_check.sql
@@ -1,7 +1,3 @@
--- scraped_records : lien vers la profession utilisée lors du scrape.
--- Nullable car les fiches existantes n'ont pas de profession associée.
-ALTER TABLE "scraped_records" ADD COLUMN "profession_id" integer REFERENCES "professions"("id") ON DELETE SET NULL;--> statement-breakpoint
-CREATE INDEX "scraped_records_profession_id_idx" ON "scraped_records" USING btree ("profession_id");--> statement-breakpoint
-
--- credits : empêcher un solde négatif au niveau DB (protection contre les race conditions).
-ALTER TABLE "credits" ADD CONSTRAINT "credits_balance_non_negative" CHECK ("balance" >= 0);
+ALTER TABLE "scraped_records" ADD COLUMN "profession_id" integer;--> statement-breakpoint
+ALTER TABLE "scraped_records" ADD CONSTRAINT "scraped_records_profession_id_professions_id_fk" FOREIGN KEY ("profession_id") REFERENCES "public"."professions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "credits" ADD CONSTRAINT "credits_balance_non_negative" CHECK ("credits"."balance" >= 0);

--- a/drizzle/0005_scraped_profession_credits_check.sql
+++ b/drizzle/0005_scraped_profession_credits_check.sql
@@ -1,0 +1,7 @@
+-- scraped_records : lien vers la profession utilisée lors du scrape.
+-- Nullable car les fiches existantes n'ont pas de profession associée.
+ALTER TABLE "scraped_records" ADD COLUMN "profession_id" integer REFERENCES "professions"("id") ON DELETE SET NULL;--> statement-breakpoint
+CREATE INDEX "scraped_records_profession_id_idx" ON "scraped_records" USING btree ("profession_id");--> statement-breakpoint
+
+-- credits : empêcher un solde négatif au niveau DB (protection contre les race conditions).
+ALTER TABLE "credits" ADD CONSTRAINT "credits_balance_non_negative" CHECK ("balance" >= 0);

--- a/drizzle/0006_credit_tx_signup_bonus.sql
+++ b/drizzle/0006_credit_tx_signup_bonus.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "credit_transactions" DROP CONSTRAINT "credit_tx_type_check";--> statement-breakpoint
+ALTER TABLE "credit_transactions" ADD CONSTRAINT "credit_tx_type_check" CHECK ("credit_transactions"."type" IN ('purchase', 'consume', 'refund', 'admin_grant', 'signup_bonus'));

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,823 @@
+{
+  "id": "c644c210-7225-4838-ad1b-ddc2bdd107ef",
+  "prevId": "8741a187-44ed-4833-8fcc-017970264d39",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_transactions": {
+      "name": "credit_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polar_order_id": {
+          "name": "polar_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_tx_user_created_idx": {
+          "name": "credit_tx_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_transactions_user_id_user_id_fk": {
+          "name": "credit_transactions_user_id_user_id_fk",
+          "tableFrom": "credit_transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_tx_type_check": {
+          "name": "credit_tx_type_check",
+          "value": "\"credit_transactions\".\"type\" IN ('purchase', 'consume', 'refund', 'admin_grant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credits": {
+      "name": "credits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credits_user_id_user_id_fk": {
+          "name": "credits_user_id_user_id_fk",
+          "tableFrom": "credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credits_balance_non_negative": {
+          "name": "credits_balance_non_negative",
+          "value": "\"credits\".\"balance\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.excluded": {
+      "name": "excluded",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professions": {
+      "name": "professions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle": {
+          "name": "libelle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "naf_codes": {
+          "name": "naf_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "professions_category_idx": {
+          "name": "professions_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "professions_slug_unique": {
+          "name": "professions_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "professions_libelle_unique": {
+          "name": "professions_libelle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "libelle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraped_records": {
+      "name": "scraped_records",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nom": {
+          "name": "nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ville": {
+          "name": "ville",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_postal": {
+          "name": "code_postal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effectif_tranche": {
+          "name": "effectif_tranche",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forme_juridique": {
+          "name": "forme_juridique",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dirigeants": {
+          "name": "dirigeants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profession_id": {
+          "name": "profession_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraped_records_user_id_idx": {
+          "name": "scraped_records_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_source_idx": {
+          "name": "scraped_records_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_code_postal_idx": {
+          "name": "scraped_records_code_postal_idx",
+          "columns": [
+            {
+              "expression": "code_postal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_telephone_idx": {
+          "name": "scraped_records_telephone_idx",
+          "columns": [
+            {
+              "expression": "telephone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scraped_records_user_id_user_id_fk": {
+          "name": "scraped_records_user_id_user_id_fk",
+          "tableFrom": "scraped_records",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scraped_records_profession_id_professions_id_fk": {
+          "name": "scraped_records_profession_id_professions_id_fk",
+          "tableFrom": "scraped_records",
+          "tableTo": "professions",
+          "columnsFrom": [
+            "profession_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scraped_records_user_id_siret_pk": {
+          "name": "scraped_records_user_id_siret_pk",
+          "columns": [
+            "user_id",
+            "siret"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,823 @@
+{
+  "id": "7673e26a-423e-479c-95e3-06739d2f94bd",
+  "prevId": "c644c210-7225-4838-ad1b-ddc2bdd107ef",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_transactions": {
+      "name": "credit_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polar_order_id": {
+          "name": "polar_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_tx_user_created_idx": {
+          "name": "credit_tx_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_transactions_user_id_user_id_fk": {
+          "name": "credit_transactions_user_id_user_id_fk",
+          "tableFrom": "credit_transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_tx_type_check": {
+          "name": "credit_tx_type_check",
+          "value": "\"credit_transactions\".\"type\" IN ('purchase', 'consume', 'refund', 'admin_grant', 'signup_bonus')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credits": {
+      "name": "credits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credits_user_id_user_id_fk": {
+          "name": "credits_user_id_user_id_fk",
+          "tableFrom": "credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credits_balance_non_negative": {
+          "name": "credits_balance_non_negative",
+          "value": "\"credits\".\"balance\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.excluded": {
+      "name": "excluded",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professions": {
+      "name": "professions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle": {
+          "name": "libelle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "naf_codes": {
+          "name": "naf_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "professions_category_idx": {
+          "name": "professions_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "professions_slug_unique": {
+          "name": "professions_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "professions_libelle_unique": {
+          "name": "professions_libelle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "libelle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraped_records": {
+      "name": "scraped_records",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nom": {
+          "name": "nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ville": {
+          "name": "ville",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_postal": {
+          "name": "code_postal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effectif_tranche": {
+          "name": "effectif_tranche",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forme_juridique": {
+          "name": "forme_juridique",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dirigeants": {
+          "name": "dirigeants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profession_id": {
+          "name": "profession_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraped_records_user_id_idx": {
+          "name": "scraped_records_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_source_idx": {
+          "name": "scraped_records_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_code_postal_idx": {
+          "name": "scraped_records_code_postal_idx",
+          "columns": [
+            {
+              "expression": "code_postal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_telephone_idx": {
+          "name": "scraped_records_telephone_idx",
+          "columns": [
+            {
+              "expression": "telephone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scraped_records_user_id_user_id_fk": {
+          "name": "scraped_records_user_id_user_id_fk",
+          "tableFrom": "scraped_records",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scraped_records_profession_id_professions_id_fk": {
+          "name": "scraped_records_profession_id_professions_id_fk",
+          "tableFrom": "scraped_records",
+          "tableTo": "professions",
+          "columnsFrom": [
+            "profession_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scraped_records_user_id_siret_pk": {
+          "name": "scraped_records_user_id_siret_pk",
+          "columns": [
+            "user_id",
+            "siret"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776853030348,
       "tag": "0004_professions_extended",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777019914831,
+      "tag": "0005_scraped_profession_credits_check",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777019914831,
       "tag": "0005_scraped_profession_credits_check",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1777021811712,
+      "tag": "0006_credit_tx_signup_bonus",
+      "breakpoints": true
     }
   ]
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -57,6 +57,9 @@ export const auth = betterAuth({
             await db.transaction((tx) => grantSignupBonus(createdUser.id, SIGNUP_CREDITS, tx));
           } catch (err) {
             console.error("[auth] échec crédit initial", { userId: createdUser.id, err });
+            // throw intentionnel : on préfère bloquer le signup plutôt que laisser
+            // un user sans crédits. Si la DB credits est indisponible, Better Auth
+            // annule la réponse et l'utilisateur peut retenter l'inscription.
             throw err;
           }
         },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,7 +2,8 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { admin } from "better-auth/plugins";
 import { db } from "./db/client.js";
-import { user, session, account, verification, credits } from "./db/schema.js";
+import { user, session, account, verification } from "./db/schema.js";
+import { SIGNUP_CREDITS, grantSignupBonus } from "./db/credits.js";
 
 const secret = process.env.BETTER_AUTH_SECRET;
 if (!secret) {
@@ -18,8 +19,6 @@ const trustedOrigins = [baseURL, ...extraOrigins];
 const googleClientId = process.env.GOOGLE_OAUTH_CLIENT_ID;
 const googleClientSecret = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
 const isProd = process.env.NODE_ENV === "production";
-
-const SIGNUP_CREDITS = 50;
 
 export const auth = betterAuth({
   secret,
@@ -55,16 +54,7 @@ export const auth = betterAuth({
       create: {
         after: async (createdUser) => {
           try {
-            const inserted = await db
-              .insert(credits)
-              .values({ userId: createdUser.id, balance: SIGNUP_CREDITS })
-              .onConflictDoNothing()
-              .returning({ userId: credits.userId });
-            if (inserted.length === 0) {
-              console.warn("[auth] crédit initial non appliqué (ligne existante)", {
-                userId: createdUser.id,
-              });
-            }
+            await db.transaction((tx) => grantSignupBonus(createdUser.id, SIGNUP_CREDITS, tx));
           } catch (err) {
             console.error("[auth] échec crédit initial", { userId: createdUser.id, err });
             throw err;

--- a/src/db/credits.ts
+++ b/src/db/credits.ts
@@ -1,0 +1,117 @@
+import { desc, eq, sql } from "drizzle-orm";
+import { db, type Db } from "./client.js";
+import { credits, creditTransactions, type CreditTransactionRow } from "./schema.js";
+
+export const SIGNUP_CREDITS = 50;
+
+export type DbOrTx = Db | Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+export class InsufficientCreditsError extends Error {
+  constructor(public readonly userId: string) {
+    super(`Crédits insuffisants pour l'utilisateur ${userId}`);
+    this.name = "InsufficientCreditsError";
+  }
+}
+
+function isCheckViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: string }).code === "23514"
+  );
+}
+
+export async function getBalance(userId: string): Promise<number> {
+  const [row] = await db
+    .select({ balance: credits.balance })
+    .from(credits)
+    .where(eq(credits.userId, userId))
+    .limit(1);
+  return row?.balance ?? 0;
+}
+
+export async function getRecentTransactions(
+  userId: string,
+  limit = 20,
+): Promise<CreditTransactionRow[]> {
+  return db
+    .select()
+    .from(creditTransactions)
+    .where(eq(creditTransactions.userId, userId))
+    .orderBy(desc(creditTransactions.createdAt))
+    .limit(limit);
+}
+
+export async function grantSignupBonus(
+  userId: string,
+  amount: number,
+  tx: DbOrTx,
+): Promise<void> {
+  const inserted = await tx
+    .insert(credits)
+    .values({ userId, balance: amount })
+    .onConflictDoNothing({ target: credits.userId })
+    .returning({ userId: credits.userId });
+
+  if (inserted.length === 0) {
+    console.warn("[credits] signup bonus ignoré — ligne credits déjà présente", { userId });
+    return;
+  }
+
+  await tx.insert(creditTransactions).values({
+    userId,
+    type: "signup_bonus",
+    amount,
+  });
+}
+
+export async function consumeOne(userId: string, tx: DbOrTx): Promise<void> {
+  try {
+    const updated = await tx
+      .update(credits)
+      .set({ balance: sql`${credits.balance} - 1` })
+      .where(eq(credits.userId, userId))
+      .returning({ userId: credits.userId });
+
+    if (updated.length === 0) {
+      throw new InsufficientCreditsError(userId);
+    }
+
+    await tx.insert(creditTransactions).values({
+      userId,
+      type: "consume",
+      amount: -1,
+    });
+  } catch (err) {
+    if (isCheckViolation(err)) {
+      throw new InsufficientCreditsError(userId);
+    }
+    throw err;
+  }
+}
+
+export async function adminGrant(userId: string, amount: number): Promise<void> {
+  if (amount <= 0) {
+    throw new Error("adminGrant: amount doit être > 0");
+  }
+
+  await db.transaction(async (tx) => {
+    const updated = await tx
+      .update(credits)
+      .set({ balance: sql`${credits.balance} + ${amount}` })
+      .where(eq(credits.userId, userId))
+      .returning({ userId: credits.userId });
+
+    if (updated.length === 0) {
+      await tx.insert(credits).values({ userId, balance: amount });
+    }
+
+    await tx.insert(creditTransactions).values({
+      userId,
+      type: "admin_grant",
+      amount,
+    });
+  });
+}
+

--- a/src/db/credits.ts
+++ b/src/db/credits.ts
@@ -1,9 +1,10 @@
-import { desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { db, type Db } from "./client.js";
 import { credits, creditTransactions, type CreditTransactionRow } from "./schema.js";
 
 export const SIGNUP_CREDITS = 50;
 
+// Introspection interne — vérifier à chaque bump majeur de drizzle-orm
 export type DbOrTx = Db | Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 export class InsufficientCreditsError extends Error {
@@ -48,14 +49,20 @@ export async function grantSignupBonus(
   amount: number,
   tx: DbOrTx,
 ): Promise<void> {
-  const inserted = await tx
+  await tx
     .insert(credits)
     .values({ userId, balance: amount })
-    .onConflictDoNothing({ target: credits.userId })
-    .returning({ userId: credits.userId });
+    .onConflictDoNothing({ target: credits.userId });
 
-  if (inserted.length === 0) {
-    console.warn("[credits] signup bonus ignoré — ligne credits déjà présente", { userId });
+  // Vérifie si la transaction signup_bonus existe déjà (idempotence sur crash partiel)
+  const existingTx = await tx
+    .select({ id: creditTransactions.id })
+    .from(creditTransactions)
+    .where(and(eq(creditTransactions.userId, userId), eq(creditTransactions.type, "signup_bonus")))
+    .limit(1);
+
+  if (existingTx.length > 0) {
+    console.warn("[credits] signup bonus déjà tracé", { userId });
     return;
   }
 
@@ -75,7 +82,7 @@ export async function consumeOne(userId: string, tx: DbOrTx): Promise<void> {
       .returning({ userId: credits.userId });
 
     if (updated.length === 0) {
-      throw new InsufficientCreditsError(userId);
+      throw new Error(`credits row manquante pour userId=${userId}`);
     }
 
     await tx.insert(creditTransactions).values({
@@ -97,15 +104,13 @@ export async function adminGrant(userId: string, amount: number): Promise<void> 
   }
 
   await db.transaction(async (tx) => {
-    const updated = await tx
-      .update(credits)
-      .set({ balance: sql`${credits.balance} + ${amount}` })
-      .where(eq(credits.userId, userId))
-      .returning({ userId: credits.userId });
-
-    if (updated.length === 0) {
-      await tx.insert(credits).values({ userId, balance: amount });
-    }
+    await tx
+      .insert(credits)
+      .values({ userId, balance: amount })
+      .onConflictDoUpdate({
+        target: credits.userId,
+        set: { balance: sql`${credits.balance} + ${amount}` },
+      });
 
     await tx.insert(creditTransactions).values({
       userId,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -91,6 +91,7 @@ export const scrapedRecords = pgTable(
     formeJuridique:  text("forme_juridique"),
     dirigeants:      text("dirigeants"),
     source:          text("source").notNull(),
+    professionId:    integer("profession_id").references(() => professions.id, { onDelete: "set null" }),
     scrapedAt:       timestamp("scraped_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
@@ -124,10 +125,14 @@ export const professions = pgTable(
 );
 
 // Solde de crédits par user (1 fiche affichée = 1 crédit consommé en #47).
-export const credits = pgTable("credits", {
-  userId:  text("user_id").primaryKey().references(() => user.id, { onDelete: "cascade" }),
-  balance: integer("balance").notNull().default(0),
-});
+export const credits = pgTable(
+  "credits",
+  {
+    userId:  text("user_id").primaryKey().references(() => user.id, { onDelete: "cascade" }),
+    balance: integer("balance").notNull().default(0),
+  },
+  (t) => [check("credits_balance_non_negative", sql`${t.balance} >= 0`)],
+);
 
 // Historique des mouvements de crédits — achats, consommations, refunds, grants admin.
 export const creditTransactions = pgTable(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -149,7 +149,7 @@ export const creditTransactions = pgTable(
     index("credit_tx_user_created_idx").on(t.userId, t.createdAt),
     check(
       "credit_tx_type_check",
-      sql`${t.type} IN ('purchase', 'consume', 'refund', 'admin_grant')`,
+      sql`${t.type} IN ('purchase', 'consume', 'refund', 'admin_grant', 'signup_bonus')`,
     ),
   ],
 );

--- a/src/db/scraped.ts
+++ b/src/db/scraped.ts
@@ -161,10 +161,14 @@ export async function insert(record: ScrapedRecord): Promise<void> {
 // Insert une fiche + consomme 1 crédit atomiquement. Si la fiche existe déjà
 // (conflit sur la PK (user_id, siret)), on skip sans débiter. Propage
 // InsufficientCreditsError si le user est à sec — le caller doit l'attraper.
+// Les fiches source='non_trouvé' coûtent aussi 1 crédit (1 établissement traité = 1 crédit, intentionnel).
 export async function insertWithCreditConsume(
   record: ScrapedRecord,
   userId: string,
 ): Promise<boolean> {
+  if (record.userId !== userId) {
+    throw new Error(`userId mismatch: record.userId=${record.userId} userId=${userId}`);
+  }
   return db.transaction(async (tx) => {
     const insertedRows = await tx
       .insert(scrapedRecords)

--- a/src/db/scraped.ts
+++ b/src/db/scraped.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, ilike, inArray, like, sql, type SQL } from "drizzle-orm";
 import { db, pgClient } from "./client.js";
 import { scrapedRecords, excluded } from "./schema.js";
+import { consumeOne } from "./credits.js";
 import { phoneTypeCondition } from "../phoneUtils.js";
 // Les filtres consommes par la couche DB — formes miroir du schema Zod
 // cote HTTP, mais avec "sourceFilter" comme nom interne (le param HTTP
@@ -155,6 +156,42 @@ export async function insert(record: ScrapedRecord): Promise<void> {
       scrapedAt: new Date(record.scrapedAt),
     })
     .onConflictDoNothing({ target: [scrapedRecords.userId, scrapedRecords.siret] });
+}
+
+// Insert une fiche + consomme 1 crédit atomiquement. Si la fiche existe déjà
+// (conflit sur la PK (user_id, siret)), on skip sans débiter. Propage
+// InsufficientCreditsError si le user est à sec — le caller doit l'attraper.
+export async function insertWithCreditConsume(
+  record: ScrapedRecord,
+  userId: string,
+): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    const insertedRows = await tx
+      .insert(scrapedRecords)
+      .values({
+        siret: record.siret,
+        userId: record.userId,
+        nom: record.nom,
+        adresse: record.adresse,
+        ville: record.ville,
+        codePostal: record.codePostal,
+        telephone: record.telephone,
+        effectifTranche: record.effectifTranche,
+        formeJuridique: record.formeJuridique,
+        dirigeants: record.dirigeants,
+        source: record.source,
+        scrapedAt: new Date(record.scrapedAt),
+      })
+      .onConflictDoNothing({ target: [scrapedRecords.userId, scrapedRecords.siret] })
+      .returning({ siret: scrapedRecords.siret });
+
+    if (insertedRows.length === 0) {
+      return false;
+    }
+
+    await consumeOne(userId, tx);
+    return true;
+  });
 }
 
 export async function getStats(userId: string): Promise<ScrapedStats> {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,5 +1,6 @@
 import { Etablissement } from "./sirene.js";
-import { isKnownByUser, insert, ScrapedRecord } from "./db/scraped.js";
+import { isKnownByUser, insertWithCreditConsume, ScrapedRecord } from "./db/scraped.js";
+import { InsufficientCreditsError } from "./db/credits.js";
 import { findPhoneGoogle } from "./googleMaps.js";
 import { fetchDirigeants } from "./annuaireEntreprises.js";
 
@@ -8,6 +9,7 @@ export interface PipelineResult {
   alreadyKnown: number;
   notFoundCount: number;
   prospects: ScrapedRecord[];
+  stoppedForCredits?: boolean;
 }
 
 export type ProgressCallback = (current: number, nom: string) => void;
@@ -22,6 +24,7 @@ export async function runPipeline(
   let alreadyKnown = 0;
   let notFoundCount = 0;
   const prospects: ScrapedRecord[] = [];
+  let stoppedForCredits = false;
   let i = 0;
 
   for await (const etab of source) {
@@ -40,12 +43,6 @@ export async function runPipeline(
       await new Promise((r) => setTimeout(r, 200));
       const scrapeSource = phone !== null ? "google" : "non_trouvé";
 
-      if (phone === null) {
-        notFoundCount++;
-      } else {
-        newCount++;
-      }
-
       const record: ScrapedRecord = {
         siret: etab.siret,
         userId,
@@ -61,12 +58,27 @@ export async function runPipeline(
         scrapedAt: new Date().toISOString(),
       };
 
-      await insert(record);
+      try {
+        const inserted = await insertWithCreditConsume(record, userId);
+        if (!inserted) {
+          alreadyKnown++;
+          continue;
+        }
+      } catch (err) {
+        if (err instanceof InsufficientCreditsError) {
+          stoppedForCredits = true;
+          break;
+        }
+        throw err;
+      }
 
-      if (scrapeSource !== "non_trouvé") {
+      if (phone === null) {
+        notFoundCount++;
+      } else {
+        newCount++;
         prospects.push(record);
       }
   }
 
-  return { newCount, alreadyKnown, notFoundCount, prospects };
+  return { newCount, alreadyKnown, notFoundCount, prospects, stoppedForCredits };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -102,7 +102,6 @@ app.get("/api/credits", requireAuth, asyncHandler(async (req, res) => {
       id: t.id,
       type: t.type,
       amount: t.amount,
-      polarOrderId: t.polarOrderId,
       createdAt: t.createdAt.toISOString(),
     })),
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { auth } from "./auth.js";
 import { requireAuth, dashboardGuard, alreadyAuthGuard } from "./middleware/auth.js";
 import { validateBody, validateQuery, getValidatedQuery } from "./middleware/validate.js";
 import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped.js";
+import { getBalance, getRecentTransactions } from "./db/credits.js";
 import { listActiveProfessions, getProfessionById } from "./db/professions.js";
 import { sql } from "drizzle-orm";
 import { db, closeDb } from "./db/client.js";
@@ -40,7 +41,7 @@ interface ScrapeState {
   total: number;
   current: string;
   error?: string;
-  result?: { newCount: number; alreadyKnown: number; notFoundCount: number };
+  result?: { newCount: number; alreadyKnown: number; notFoundCount: number; stoppedForCredits?: boolean };
   finishedAt?: number;
 }
 
@@ -87,6 +88,24 @@ app.use(express.static(path.join(__dirname, "public")));
 app.get("/api/me", requireAuth, asyncHandler(async (req, res) => {
   const result = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) });
   res.json(result);
+}));
+
+app.get("/api/credits", requireAuth, asyncHandler(async (req, res) => {
+  const userId = req.user!.id;
+  const [balance, recentTransactions] = await Promise.all([
+    getBalance(userId),
+    getRecentTransactions(userId),
+  ]);
+  res.json({
+    balance,
+    recentTransactions: recentTransactions.map((t) => ({
+      id: t.id,
+      type: t.type,
+      amount: t.amount,
+      polarOrderId: t.polarOrderId,
+      createdAt: t.createdAt.toISOString(),
+    })),
+  });
 }));
 
 function pickFilters(query: ResultsQuery | ExportQuery): ResultFilters {
@@ -185,7 +204,11 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), asyncHandle
       newCount: result.newCount,
       alreadyKnown: result.alreadyKnown,
       notFoundCount: result.notFoundCount,
+      stoppedForCredits: result.stoppedForCredits,
     };
+    if (result.stoppedForCredits) {
+      state.error = "Crédits insuffisants — scrape arrêté avant la fin";
+    }
     state.finishedAt = Date.now();
   })().catch((err) => {
     state.status = "done";


### PR DESCRIPTION
## Contexte

Implémentation du système de crédits freemium (option A) : 1 crédit consommé par fiche insérée, peu importe la source (google ou non_trouvé).

Closes #47

## Ce qui a changé

- `GET /api/credits` — retourne le solde actuel et les 20 dernières transactions
- Chaque fiche insérée consomme 1 crédit (atomique, même transaction Postgres)
- Le pipeline s'arrête proprement si le solde atteint 0 (`GET /api/status` retourne un message explicite)
- Le bonus de 50 crédits au signup est maintenant tracé dans `credit_transactions` (type `signup_bonus`) et visible dans l'historique
- Migration `0006` : ajout du type `signup_bonus` dans le CHECK `credit_tx_type_check`
- Nouveau module `src/db/credits.ts` : `getBalance`, `getRecentTransactions`, `grantSignupBonus`, `consumeOne`, `adminGrant` + `InsufficientCreditsError`

## Points d'attention

- Les fiches `source='non_trouvé'` coûtent 1 crédit (comportement intentionnel et documenté)
- `adminGrant` est une fonction interne uniquement (pas d'endpoint HTTP dans cette PR)
- `grantSignupBonus` est idempotent via vérification de la transaction `signup_bonus` (résistant aux crashs partiels entre INSERT credits et INSERT credit_transactions)