### PR TITLE
[Feature] Pré-check 0 crédit → 402 Payment Required + popup frontend (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `POST /api/scrape` retourne `402 Payment Required` si le solde est à 0 avant le lancement du scrape, avec body `{ error: "INSUFFICIENT_CREDITS", balance: 0 }` ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
+- Solde de crédits affiché dans le dashboard : badge dans la sidebar (orange ≤10 crédits, rouge à 0), actualisé en temps réel pendant le scrape ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
+- Popup "Crédits épuisés" avec CTA de recharge : affichée au clic si solde nul, sur réponse 402, ou quand le pipeline s'arrête en cours de route faute de crédits ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
+- `GET /api/status` retourne désormais `status: "error"` quand le pipeline rencontre une erreur inattendue ; le dashboard affiche un toast explicite au lieu d'un résumé vide ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
+
 - Les 50 crédits offerts à l'inscription sont désormais tracés dans l'historique et visibles via `GET /api/credits` (transaction `signup_bonus`) ([`12a7fbf`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/12a7fbf))
 - Chaque fiche insérée lors d'un scrape consomme automatiquement 1 crédit ; le pipeline s'arrête si le solde atteint 0 et `GET /api/status` retourne un message explicite ([`f371473`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/f371473))
 - `GET /api/credits` — retourne le solde actuel et les 20 dernières transactions (type, montant, date) ([`8c561d0`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/8c561d0))
@@ -25,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- La popup "Crédits épuisés" s'affiche correctement si le solde n'était pas encore chargé au moment du premier clic (race condition au chargement de la page) ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
 - L'insertion d'une fiche et le décrément du crédit s'effectuent dans la même transaction Postgres : un crash ne peut ni débiter sans insérer, ni insérer sans débiter ([`bc3deb9`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/bc3deb9))
 - Les filtres par nom et ville du dashboard sont désormais insensibles à la casse (comportement SQLite restauré sous Postgres via `ILIKE`) ([`86aa1b4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/86aa1b4))
 - `GET /api/export` streame désormais le CSV ligne par ligne via un curseur Postgres : plus de timeout HTTP ni de saturation mémoire sur de grands volumes ([`e6909ab`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/e6909ab))

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Refactor
 
-- `src/auth.ts` : hook signup délégué à `grantSignupBonus(tx)` — idempotence basée sur la présence d'une transaction `signup_bonus` plutôt que la ligne `credits` (résistant aux crashs partiels) ([`6f79a24`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/6f79a24))
-- `src/db/scraped.ts` : nouvelle fonction `insertWithCreditConsume` — transaction atomique insert + `consumeOne` avec guard `userId mismatch` en entrée ([`bc3deb9`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/bc3deb9))
+- `src/server.ts` : `ScrapeState.status` étendu avec `"stopped_no_credits"` (pipeline arrêté faute de crédits) et `"error"` (exception inattendue dans le pipeline) ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
 
 ### Chore
 
+- `src/server.ts` : commentaire explicite que le pré-check `getBalance` est UX uniquement — la garantie atomique reste la contrainte CHECK Postgres dans `consumeOne` ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
+- `src/server.ts` : `console.warn` émis si `balance <= 0` pour signaler les cas de row `credits` absente (bug de provisioning) vs solde réellement épuisé ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
 - Nouveau module `src/db/credits.ts` : services `getBalance`, `getRecentTransactions`, `grantSignupBonus`, `consumeOne`, `adminGrant` + `InsufficientCreditsError` ([`12a7fbf`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/12a7fbf))
 - Migration `0006_credit_tx_signup_bonus.sql` : ajout de `signup_bonus` dans le CHECK `credit_tx_type_check` de `credit_transactions` ([`eef50cd`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/eef50cd))
 - Migration vers ESM (`"type": "module"` + `tsconfig NodeNext`) : 15 fichiers d'imports suffixés `.js`, `__dirname` remplacé par `fileURLToPath` — résout `ERR_REQUIRE_ESM` au démarrage causé par `better-auth/node` (ESM-only) ([`c522acd`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/c522acd))

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1101,6 +1101,28 @@
     </div>
   </div>
 
+  <!-- Modal crédits épuisés -->
+  <div class="modal-overlay" id="noCreditsModal" onclick="closeNoCreditsModal(event)">
+    <div class="modal" style="max-width:420px">
+      <div class="modal-header">
+        <div>
+          <div class="modal-title">Crédits épuisés</div>
+          <div class="modal-subtitle">Rechargez votre solde pour lancer un nouveau scrape.</div>
+        </div>
+        <button class="modal-close" onclick="closeNoCreditsModal()">✕</button>
+      </div>
+      <div class="modal-body" style="padding:1.2rem 1.5rem">
+        <p style="color:var(--muted); font-size:0.75rem; line-height:1.55; margin-bottom:1.2rem">
+          Chaque fiche enregistrée consomme 1 crédit. Ton solde est actuellement à 0 — impossible de démarrer ou de poursuivre un scrape.
+        </p>
+        <div style="display:flex; gap:0.6rem; justify-content:flex-end">
+          <button class="btn-run" style="background:var(--bg-elevated); color:var(--muted)" onclick="closeNoCreditsModal()">Annuler</button>
+          <button class="btn-run" onclick="window.location.href='/billing'">Recharger mes crédits</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Toast container -->
   <div class="toast-container" id="toastContainer"></div>
 
@@ -1252,6 +1274,14 @@
     function closeDupModal(e) {
       if (e && e.target !== document.getElementById("dupModal")) return;
       document.getElementById("dupModal").classList.remove("open");
+    }
+
+    function openNoCreditsModal() {
+      document.getElementById("noCreditsModal").classList.add("open");
+    }
+    function closeNoCreditsModal(e) {
+      if (e && e.target !== document.getElementById("noCreditsModal")) return;
+      document.getElementById("noCreditsModal").classList.remove("open");
     }
 
     /* ── Doublons par numéro ── */
@@ -1748,6 +1778,9 @@ function setExportScope(scope) {
     document.addEventListener("keydown", function(e) {
       if (e.key === "Enter" && e.target.closest(".sidebar") && !document.getElementById("btnScrape").disabled) {
         startScrape();
+      }
+      if (e.key === "Escape") {
+        closeNoCreditsModal();
       }
     });
   </script>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1624,7 +1624,7 @@
     async function startScrape() {
       const btn = document.getElementById("btnScrape");
 
-      if (currentBalance === 0) {
+      if (currentBalance !== null && currentBalance <= 0) {
         openNoCreditsModal();
         return;
       }
@@ -1664,7 +1664,6 @@
       }
 
       if (res.status === 402) {
-        currentBalance = 0;
         refreshCredits();
         openNoCreditsModal();
         btn.disabled = false;
@@ -1704,6 +1703,7 @@
         state.status === "running" ? "En cours…" :
         state.status === "done" ? "Terminé" :
         state.status === "stopped_no_credits" ? "Crédits épuisés" :
+        state.status === "error" ? "Erreur" :
         "En attente";
 
       refreshCredits();
@@ -1714,6 +1714,15 @@
         document.getElementById("progressPct").textContent   = pct + "%";
         document.getElementById("progressCount").textContent = state.progress + " / " + state.total;
         document.getElementById("progressLabel").textContent = state.current || "—";
+      }
+
+      if (state.status === "error") {
+        clearInterval(pollInterval); pollInterval = null;
+        document.getElementById("btnScrape").disabled = false;
+        toast("Erreur scrape — " + (state.error || "erreur inconnue"), "warn");
+        setTimeout(function() {
+          document.getElementById("progressBlock").classList.remove("visible");
+        }, 4000);
       }
 
       if (state.status === "stopped_no_credits") {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -24,6 +24,8 @@
       --success-dim:  rgba(34,197,94,0.1);
       --warn:         #f59e0b;
       --warn-dim:     rgba(245,158,11,0.1);
+      --danger:       #ef4444;
+      --danger-dim:   rgba(239,68,68,0.12);
       --mono: 'JetBrains Mono', 'Courier New', monospace;
     }
 
@@ -92,6 +94,27 @@
     }
     .status-dot.running { background: var(--warn); box-shadow: 0 0 6px var(--warn); animation: blink 1.4s ease-in-out infinite; }
     .status-dot.done    { background: var(--success); box-shadow: 0 0 6px var(--success); }
+    .status-dot.stopped_no_credits { background: var(--danger); box-shadow: 0 0 6px var(--danger); }
+
+    .credit-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      margin-top: 0.5rem;
+      padding: 0.28rem 0.6rem;
+      border-radius: 100px;
+      font-size: 0.6rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border-hover);
+      color: var(--text);
+    }
+    .credit-chip .credit-value { font-weight: 700; color: var(--accent); }
+    .credit-chip.low { border-color: var(--warn); }
+    .credit-chip.low .credit-value { color: var(--warn); }
+    .credit-chip.empty { border-color: var(--danger); background: var(--danger-dim); }
+    .credit-chip.empty .credit-value { color: var(--danger); }
 
     @keyframes blink { 0%,100% { opacity:1; } 50% { opacity:0.3; } }
 
@@ -760,6 +783,10 @@
       <div class="status-chip">
         <span class="status-dot" id="statusDot"></span>
         <span id="statusText">En attente</span>
+      </div>
+      <div class="credit-chip" id="creditChip" title="Crédits disponibles">
+        <span class="credit-value" id="creditBalance">—</span>
+        <span>crédits</span>
       </div>
     </div>
 
@@ -1604,6 +1631,22 @@
       if (!pollInterval) pollInterval = setInterval(pollStatus, 1000);
     }
 
+    /* ── Credits ── */
+    let currentBalance = null;
+    async function refreshCredits() {
+      try {
+        const r = await fetch("/api/credits");
+        if (!r.ok) return;
+        const data = await r.json();
+        currentBalance = data.balance;
+        const el = document.getElementById("creditBalance");
+        const chip = document.getElementById("creditChip");
+        el.textContent = data.balance;
+        chip.classList.toggle("empty", data.balance <= 0);
+        chip.classList.toggle("low", data.balance > 0 && data.balance <= 10);
+      } catch {}
+    }
+
     /* ── Status polling ── */
     async function pollStatus() {
       let state;
@@ -1613,7 +1656,13 @@
       const dot  = document.getElementById("statusDot");
       const text = document.getElementById("statusText");
       dot.className     = "status-dot " + state.status;
-      text.textContent  = state.status === "running" ? "En cours…" : state.status === "done" ? "Terminé" : "En attente";
+      text.textContent  =
+        state.status === "running" ? "En cours…" :
+        state.status === "done" ? "Terminé" :
+        state.status === "stopped_no_credits" ? "Crédits épuisés" :
+        "En attente";
+
+      refreshCredits();
 
       if (state.status === "running") {
         const pct = state.total > 0 ? Math.round((state.progress / state.total) * 100) : 0;
@@ -1684,6 +1733,7 @@ function setExportScope(scope) {
     fetchRegions();
     fetchProfessions();
     fetchFilterOptions();
+    refreshCredits();
     pollStatus();
 
     /* Auto-refresh résultats toutes les 10s si idle */

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1623,6 +1623,12 @@
     /* ── Scrape ── */
     async function startScrape() {
       const btn = document.getElementById("btnScrape");
+
+      if (currentBalance === 0) {
+        openNoCreditsModal();
+        return;
+      }
+
       btn.disabled = true;
       document.getElementById("resultBlock").classList.remove("visible");
 
@@ -1653,6 +1659,14 @@
 
       if (res.status === 409) {
         toast("Un scrape est déjà en cours", "warn");
+        btn.disabled = false;
+        return;
+      }
+
+      if (res.status === 402) {
+        currentBalance = 0;
+        refreshCredits();
+        openNoCreditsModal();
         btn.disabled = false;
         return;
       }
@@ -1700,6 +1714,18 @@
         document.getElementById("progressPct").textContent   = pct + "%";
         document.getElementById("progressCount").textContent = state.progress + " / " + state.total;
         document.getElementById("progressLabel").textContent = state.current || "—";
+      }
+
+      if (state.status === "stopped_no_credits") {
+        clearInterval(pollInterval); pollInterval = null;
+        document.getElementById("btnScrape").disabled = false;
+        toast("Scrape arrêté — crédits épuisés", "warn");
+        openNoCreditsModal();
+        fetchStats();
+        fetchResults();
+        setTimeout(function() {
+          document.getElementById("progressBlock").classList.remove("visible");
+        }, 4000);
       }
 
       if (state.status === "done") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -160,6 +160,12 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), asyncHandle
     return;
   }
 
+  const balance = await getBalance(userId);
+  if (balance <= 0) {
+    res.status(402).json({ error: "INSUFFICIENT_CREDITS", balance });
+    return;
+  }
+
   const { region, departement, all, limit, professionId } = req.body as ScrapeBody;
 
   let nafCodes: string[] | undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,7 +36,7 @@ const app = express();
 const PORT = Number(process.env.PORT) || 3000;
 
 interface ScrapeState {
-  status: "idle" | "running" | "done" | "stopped_no_credits";
+  status: "idle" | "running" | "done" | "stopped_no_credits" | "error";
   progress: number;
   total: number;
   current: string;
@@ -160,8 +160,11 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), asyncHandle
     return;
   }
 
+  // Pré-check UX uniquement — la vraie garantie d'atomicité est la contrainte
+  // CHECK Postgres (balance >= 0) appliquée dans consumeOne via insertWithCreditConsume.
   const balance = await getBalance(userId);
   if (balance <= 0) {
+    if (balance === 0) console.warn(`[billing] solde=0 pour userId=${userId} — row credits absente ou solde épuisé`);
     res.status(402).json({ error: "INSUFFICIENT_CREDITS", balance });
     return;
   }
@@ -216,7 +219,7 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), asyncHandle
     }
     state.finishedAt = Date.now();
   })().catch((err) => {
-    state.status = "done";
+    state.status = "error";
     state.error = err instanceof Error ? err.message : String(err);
     state.finishedAt = Date.now();
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,7 +36,7 @@ const app = express();
 const PORT = Number(process.env.PORT) || 3000;
 
 interface ScrapeState {
-  status: "idle" | "running" | "done";
+  status: "idle" | "running" | "done" | "stopped_no_credits";
   progress: number;
   total: number;
   current: string;
@@ -204,7 +204,7 @@ app.post("/api/scrape", requireAuth, validateBody(scrapeBodySchema), asyncHandle
       state.current = nom;
     }, limit);
 
-    state.status = "done";
+    state.status = result.stoppedForCredits ? "stopped_no_credits" : "done";
     state.result = {
       newCount: result.newCount,
       alreadyKnown: result.alreadyKnown,


### PR DESCRIPTION
## Contexte

Closes #48

Bloque le lancement d'un scrape quand l'utilisateur n'a plus de crédit — côté backend (HTTP 402) et frontend (popup modale + affichage du solde en temps réel).

## Changements

- `POST /api/scrape` vérifie le solde avant de lancer le pipeline → 402 `{ error: "INSUFFICIENT_CREDITS", balance }` si `balance <= 0`
- Nouveau statut `stopped_no_credits` dans `ScrapeState` quand le pipeline s'arrête faute de crédits en cours de route
- Affichage du solde dans la sidebar (badge coloré : normal / warn ≤10 / danger à 0), rafraîchi à chaque tick de polling
- Modale "Crédits épuisés" avec CTA `/billing`, déclenchée au clic si solde nul, sur réponse 402, et sur détection `stopped_no_credits` en polling
- Toast "Scrape arrêté — crédits épuisés" quand le pipeline s'arrête en cours de route
- Statut `"error"` ajouté à `ScrapeState` pour les erreurs inattendues du pipeline (distinct de `"done"`)
- Commentaire explicite signalant que le pré-check est UX uniquement, la vraie garantie étant la contrainte CHECK Postgres dans `consumeOne`

## Tests

- [ ] `POST /api/scrape` avec balance=0 → 402 + body `{ error: "INSUFFICIENT_CREDITS", balance: 0 }`
- [ ] Clic "Lancer le scrape" avec solde affiché à 0 → popup sans envoi de requête
- [ ] Réponse 402 du serveur → popup ouvre, bouton réactivé
- [ ] Scrape avec 1 crédit et limite=5 → arrêt après 1 fiche, toast + status `stopped_no_credits`, popup
- [ ] `npx tsc --noEmit` → 0 erreur