### PR TITLE
[Feature] Admin panel basique — voir users + recharger crédits manuellement (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Panel `/admin` accessible aux utilisateurs avec le rôle `admin` : liste paginée des users (email, balance, achats, fiches scrapées), recherche par email et modal de gestion manuelle des crédits ([`c180a3b`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/c180a3b))
+- `GET /api/admin/users` — liste des users avec leurs stats (balance, total achats en crédits, total fiches scrapées) ; filtrable par email via `search`, paginable avec `limit` (max 100) et `offset` ([`c07fa71`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/c07fa71))
+- `GET /api/admin/users/:userId` — détail d'un user et ses 50 dernières transactions de crédits (type, montant, note) ([`c07fa71`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/c07fa71))
+- `POST /api/admin/users/:userId/credits` — body `{ amount, note }` : ajuste manuellement le solde (`amount` positif = crédit, négatif = débit) ; retourne `409` si le débit dépasserait le solde existant ([`c07fa71`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/c07fa71))
+- Lien "Admin" affiché dans la navbar du dashboard uniquement si l'utilisateur connecté a le rôle `admin` ([`9b92edd`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/9b92edd))
 - `POST /api/scrape` retourne `402 Payment Required` si le solde est à 0 avant le lancement du scrape, avec body `{ error: "INSUFFICIENT_CREDITS", balance: 0 }` ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
 - Solde de crédits affiché dans le dashboard : badge dans la sidebar (orange ≤10 crédits, rouge à 0), actualisé en temps réel pendant le scrape ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
 - Popup "Crédits épuisés" avec CTA de recharge : affichée au clic si solde nul, sur réponse 402, ou quand le pipeline s'arrête en cours de route faute de crédits ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
@@ -39,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Faille XSS corrigée sur la page admin : les ids utilisateurs ne sont plus interpolés dans les attributs `onclick` HTML mais stockés dans des attributs `data-user-id` ([`ea590e4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/ea590e4))
 - Routes API protégées par authentification : toutes les routes `/api/*` (sauf `/api/auth/*` et `/api/health`) retournent `401 Unauthorized` si la session est absente ; le dashboard `/` redirige vers `/login` (302) si non authentifié ([`874cd46`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/874cd46))
 - `GET /api/me` désormais protégé par le middleware d'authentification, cohérent avec le reste des routes ([`59f9104`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/59f9104))
 - Les routes `POST /api/scrape`, `GET /api/results` et `GET /api/export` valident désormais tous les inputs : une valeur invalide (région inconnue, département mal formé, limite hors plage, filtre non reconnu) retourne `400` avec le champ fautif et un message explicite, au lieu d'un comportement imprévisible ([`6601e52`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/6601e52))

--- a/TECHNICAL_CHANGES.md
+++ b/TECHNICAL_CHANGES.md
@@ -9,10 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Refactor
 
+- `src/db/credits.ts` : `adminGrant` étendu pour accepter les débits (`amount < 0`) et tracer obligatoirement `adminId`/`note` dans la colonne `metadata` ([`48d822e`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/48d822e))
+- `src/middleware/auth.ts` : factorisation de `makeAdminGuard(onUnauth, onForbidden)` pour dériver `requireAdminAuth` et `adminDashboardGuard` sans duplication ([`ea590e4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/ea590e4))
+- `src/db/admin.ts` : sous-requêtes SQL inlinées dans `listUsers`/`getUserDetail` ; `transactionLimit` paramétrable dans `getUserDetail` (défaut 50) ([`ea590e4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/ea590e4))
 - `src/server.ts` : `ScrapeState.status` étendu avec `"stopped_no_credits"` (pipeline arrêté faute de crédits) et `"error"` (exception inattendue dans le pipeline) ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
 
 ### Chore
 
+- Migration `0007_peaceful_rocket_raccoon.sql` : colonne `metadata jsonb NULL` ajoutée sur `credit_transactions` pour tracer l'auteur admin et la note de chaque ajustement manuel ([`a348129`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/a348129))
+- Nouveau module `src/db/admin.ts` : `listUsers` (pagination, recherche, agrégats balance/achats/fiches) et `getUserDetail` ([`15a8083`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/15a8083))
+- Nouveau `src/schemas/admin.schema.ts` : `adminCreditBodySchema` et `adminUsersQuerySchema` (Zod) pour valider les inputs des routes admin ([`42936d3`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/42936d3))
+- `src/views/admin.html` déplacé hors de `public/` pour ne pas être exposé par `express.static` ([`ea590e4`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/ea590e4))
 - `src/server.ts` : commentaire explicite que le pré-check `getBalance` est UX uniquement — la garantie atomique reste la contrainte CHECK Postgres dans `consumeOne` ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
 - `src/server.ts` : `console.warn` émis si `balance <= 0` pour signaler les cas de row `credits` absente (bug de provisioning) vs solde réellement épuisé ([#86](https://github.com/alex-robert-fr/entreprise-scrapper/pull/86))
 - Nouveau module `src/db/credits.ts` : services `getBalance`, `getRecentTransactions`, `grantSignupBonus`, `consumeOne`, `adminGrant` + `InsufficientCreditsError` ([`12a7fbf`](https://github.com/alex-robert-fr/entreprise-scrapper/commit/12a7fbf))

--- a/drizzle/0007_peaceful_rocket_raccoon.sql
+++ b/drizzle/0007_peaceful_rocket_raccoon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "credit_transactions" ADD COLUMN "metadata" jsonb;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,829 @@
+{
+  "id": "bc2a535e-2c55-4630-af72-82df1cd156e9",
+  "prevId": "7673e26a-423e-479c-95e3-06739d2f94bd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_transactions": {
+      "name": "credit_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polar_order_id": {
+          "name": "polar_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_tx_user_created_idx": {
+          "name": "credit_tx_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_transactions_user_id_user_id_fk": {
+          "name": "credit_transactions_user_id_user_id_fk",
+          "tableFrom": "credit_transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_tx_type_check": {
+          "name": "credit_tx_type_check",
+          "value": "\"credit_transactions\".\"type\" IN ('purchase', 'consume', 'refund', 'admin_grant', 'signup_bonus')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credits": {
+      "name": "credits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credits_user_id_user_id_fk": {
+          "name": "credits_user_id_user_id_fk",
+          "tableFrom": "credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credits_balance_non_negative": {
+          "name": "credits_balance_non_negative",
+          "value": "\"credits\".\"balance\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.excluded": {
+      "name": "excluded",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.professions": {
+      "name": "professions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "libelle": {
+          "name": "libelle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "naf_codes": {
+          "name": "naf_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "professions_category_idx": {
+          "name": "professions_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "professions_slug_unique": {
+          "name": "professions_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "professions_libelle_unique": {
+          "name": "professions_libelle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "libelle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraped_records": {
+      "name": "scraped_records",
+      "schema": "",
+      "columns": {
+        "siret": {
+          "name": "siret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nom": {
+          "name": "nom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adresse": {
+          "name": "adresse",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ville": {
+          "name": "ville",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_postal": {
+          "name": "code_postal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telephone": {
+          "name": "telephone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effectif_tranche": {
+          "name": "effectif_tranche",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forme_juridique": {
+          "name": "forme_juridique",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dirigeants": {
+          "name": "dirigeants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profession_id": {
+          "name": "profession_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraped_records_user_id_idx": {
+          "name": "scraped_records_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_source_idx": {
+          "name": "scraped_records_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_code_postal_idx": {
+          "name": "scraped_records_code_postal_idx",
+          "columns": [
+            {
+              "expression": "code_postal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scraped_records_telephone_idx": {
+          "name": "scraped_records_telephone_idx",
+          "columns": [
+            {
+              "expression": "telephone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scraped_records_user_id_user_id_fk": {
+          "name": "scraped_records_user_id_user_id_fk",
+          "tableFrom": "scraped_records",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scraped_records_profession_id_professions_id_fk": {
+          "name": "scraped_records_profession_id_professions_id_fk",
+          "tableFrom": "scraped_records",
+          "tableTo": "professions",
+          "columnsFrom": [
+            "profession_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scraped_records_user_id_siret_pk": {
+          "name": "scraped_records_user_id_siret_pk",
+          "columns": [
+            "user_id",
+            "siret"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777021811712,
       "tag": "0006_credit_tx_signup_bonus",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1777034754999,
+      "tag": "0007_peaceful_rocket_raccoon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/admin.ts
+++ b/src/db/admin.ts
@@ -28,25 +28,6 @@ export interface ListUsersOptions {
   offset?: number;
 }
 
-const totalPurchasesSql = sql<number>`
-  COALESCE((
-    SELECT SUM(${creditTransactions.amount})
-    FROM ${creditTransactions}
-    WHERE ${creditTransactions.userId} = ${user.id}
-      AND ${creditTransactions.type} = 'purchase'
-  ), 0)
-`.mapWith(Number);
-
-const totalScrapedSql = sql<number>`
-  COALESCE((
-    SELECT COUNT(*)
-    FROM ${scrapedRecords}
-    WHERE ${scrapedRecords.userId} = ${user.id}
-  ), 0)
-`.mapWith(Number);
-
-const balanceSql = sql<number>`COALESCE(${credits.balance}, 0)`.mapWith(Number);
-
 export async function listUsers(opts: ListUsersOptions = {}): Promise<AdminUserSummary[]> {
   const limit = Math.min(opts.limit ?? 50, 100);
   const offset = opts.offset ?? 0;
@@ -57,9 +38,22 @@ export async function listUsers(opts: ListUsersOptions = {}): Promise<AdminUserS
       email: user.email,
       createdAt: user.createdAt,
       role: user.role,
-      balance: balanceSql,
-      totalPurchases: totalPurchasesSql,
-      totalScraped: totalScrapedSql,
+      balance: sql<number>`COALESCE(${credits.balance}, 0)`.mapWith(Number),
+      totalPurchases: sql<number>`
+        COALESCE((
+          SELECT SUM(${creditTransactions.amount})
+          FROM ${creditTransactions}
+          WHERE ${creditTransactions.userId} = ${user.id}
+            AND ${creditTransactions.type} = 'purchase'
+        ), 0)
+      `.mapWith(Number),
+      totalScraped: sql<number>`
+        COALESCE((
+          SELECT COUNT(*)
+          FROM ${scrapedRecords}
+          WHERE ${scrapedRecords.userId} = ${user.id}
+        ), 0)
+      `.mapWith(Number),
     })
     .from(user)
     .leftJoin(credits, eq(credits.userId, user.id));
@@ -71,16 +65,32 @@ export async function listUsers(opts: ListUsersOptions = {}): Promise<AdminUserS
   return filtered.orderBy(desc(user.createdAt)).limit(limit).offset(offset);
 }
 
-export async function getUserDetail(userId: string): Promise<AdminUserDetail | null> {
+export async function getUserDetail(
+  userId: string,
+  transactionLimit = 50,
+): Promise<AdminUserDetail | null> {
   const [summary] = await db
     .select({
       id: user.id,
       email: user.email,
       createdAt: user.createdAt,
       role: user.role,
-      balance: balanceSql,
-      totalPurchases: totalPurchasesSql,
-      totalScraped: totalScrapedSql,
+      balance: sql<number>`COALESCE(${credits.balance}, 0)`.mapWith(Number),
+      totalPurchases: sql<number>`
+        COALESCE((
+          SELECT SUM(${creditTransactions.amount})
+          FROM ${creditTransactions}
+          WHERE ${creditTransactions.userId} = ${user.id}
+            AND ${creditTransactions.type} = 'purchase'
+        ), 0)
+      `.mapWith(Number),
+      totalScraped: sql<number>`
+        COALESCE((
+          SELECT COUNT(*)
+          FROM ${scrapedRecords}
+          WHERE ${scrapedRecords.userId} = ${user.id}
+        ), 0)
+      `.mapWith(Number),
     })
     .from(user)
     .leftJoin(credits, eq(credits.userId, user.id))
@@ -94,7 +104,7 @@ export async function getUserDetail(userId: string): Promise<AdminUserDetail | n
     .from(creditTransactions)
     .where(eq(creditTransactions.userId, userId))
     .orderBy(desc(creditTransactions.createdAt))
-    .limit(50);
+    .limit(transactionLimit);
 
   return { ...summary, transactions };
 }

--- a/src/db/admin.ts
+++ b/src/db/admin.ts
@@ -1,0 +1,100 @@
+import { desc, eq, ilike, sql } from "drizzle-orm";
+import { db } from "./client.js";
+import {
+  user,
+  credits,
+  creditTransactions,
+  scrapedRecords,
+  type CreditTransactionRow,
+} from "./schema.js";
+
+export interface AdminUserSummary {
+  id: string;
+  email: string;
+  createdAt: Date;
+  role: string;
+  balance: number;
+  totalPurchases: number;
+  totalScraped: number;
+}
+
+export interface AdminUserDetail extends AdminUserSummary {
+  transactions: CreditTransactionRow[];
+}
+
+export interface ListUsersOptions {
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+const totalPurchasesSql = sql<number>`
+  COALESCE((
+    SELECT SUM(${creditTransactions.amount})
+    FROM ${creditTransactions}
+    WHERE ${creditTransactions.userId} = ${user.id}
+      AND ${creditTransactions.type} = 'purchase'
+  ), 0)
+`.mapWith(Number);
+
+const totalScrapedSql = sql<number>`
+  COALESCE((
+    SELECT COUNT(*)
+    FROM ${scrapedRecords}
+    WHERE ${scrapedRecords.userId} = ${user.id}
+  ), 0)
+`.mapWith(Number);
+
+const balanceSql = sql<number>`COALESCE(${credits.balance}, 0)`.mapWith(Number);
+
+export async function listUsers(opts: ListUsersOptions = {}): Promise<AdminUserSummary[]> {
+  const limit = Math.min(opts.limit ?? 50, 100);
+  const offset = opts.offset ?? 0;
+
+  const baseQuery = db
+    .select({
+      id: user.id,
+      email: user.email,
+      createdAt: user.createdAt,
+      role: user.role,
+      balance: balanceSql,
+      totalPurchases: totalPurchasesSql,
+      totalScraped: totalScrapedSql,
+    })
+    .from(user)
+    .leftJoin(credits, eq(credits.userId, user.id));
+
+  const filtered = opts.search
+    ? baseQuery.where(ilike(user.email, `%${opts.search}%`))
+    : baseQuery;
+
+  return filtered.orderBy(desc(user.createdAt)).limit(limit).offset(offset);
+}
+
+export async function getUserDetail(userId: string): Promise<AdminUserDetail | null> {
+  const [summary] = await db
+    .select({
+      id: user.id,
+      email: user.email,
+      createdAt: user.createdAt,
+      role: user.role,
+      balance: balanceSql,
+      totalPurchases: totalPurchasesSql,
+      totalScraped: totalScrapedSql,
+    })
+    .from(user)
+    .leftJoin(credits, eq(credits.userId, user.id))
+    .where(eq(user.id, userId))
+    .limit(1);
+
+  if (!summary) return null;
+
+  const transactions = await db
+    .select()
+    .from(creditTransactions)
+    .where(eq(creditTransactions.userId, userId))
+    .orderBy(desc(creditTransactions.createdAt))
+    .limit(50);
+
+  return { ...summary, transactions };
+}

--- a/src/db/credits.ts
+++ b/src/db/credits.ts
@@ -98,25 +98,44 @@ export async function consumeOne(userId: string, tx: DbOrTx): Promise<void> {
   }
 }
 
-export async function adminGrant(userId: string, amount: number): Promise<void> {
-  if (amount <= 0) {
-    throw new Error("adminGrant: amount doit être > 0");
+export interface AdminGrantOptions {
+  adminId: string;
+  note: string;
+}
+
+// Ajustement manuel admin : amount positif crédite, négatif débite.
+// En cas de débit dépassant le solde, la check constraint DB renvoie InsufficientCreditsError.
+export async function adminGrant(
+  userId: string,
+  amount: number,
+  opts: AdminGrantOptions,
+): Promise<void> {
+  if (amount === 0) {
+    throw new Error("adminGrant: amount ne peut pas être 0");
   }
 
-  await db.transaction(async (tx) => {
-    await tx
-      .insert(credits)
-      .values({ userId, balance: amount })
-      .onConflictDoUpdate({
-        target: credits.userId,
-        set: { balance: sql`${credits.balance} + ${amount}` },
-      });
+  try {
+    await db.transaction(async (tx) => {
+      await tx
+        .insert(credits)
+        .values({ userId, balance: amount })
+        .onConflictDoUpdate({
+          target: credits.userId,
+          set: { balance: sql`${credits.balance} + ${amount}` },
+        });
 
-    await tx.insert(creditTransactions).values({
-      userId,
-      type: "admin_grant",
-      amount,
+      await tx.insert(creditTransactions).values({
+        userId,
+        type: "admin_grant",
+        amount,
+        metadata: { admin_id: opts.adminId, note: opts.note },
+      });
     });
-  });
+  } catch (err) {
+    if (isCheckViolation(err)) {
+      throw new InsufficientCreditsError(userId);
+    }
+    throw err;
+  }
 }
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,3 +1,4 @@
 export * from "./schema.js";
 export * from "./scraped.js";
 export * from "./professions.js";
+export * from "./admin.js";

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -8,6 +8,7 @@ import {
   index,
   check,
   primaryKey,
+  jsonb,
 } from "drizzle-orm/pg-core";
 import { sql, type InferSelectModel, type InferInsertModel } from "drizzle-orm";
 
@@ -134,6 +135,13 @@ export const credits = pgTable(
   (t) => [check("credits_balance_non_negative", sql`${t.balance} >= 0`)],
 );
 
+// Payload JSONB optionnel sur credit_transactions — trace l'admin auteur et sa note
+// pour les ajustements manuels (type='admin_grant').
+export interface CreditTransactionMetadata {
+  admin_id?: string;
+  note?: string;
+}
+
 // Historique des mouvements de crédits — achats, consommations, refunds, grants admin.
 export const creditTransactions = pgTable(
   "credit_transactions",
@@ -143,6 +151,7 @@ export const creditTransactions = pgTable(
     type:           text("type").notNull(),
     amount:         integer("amount").notNull(),
     polarOrderId:   text("polar_order_id"),
+    metadata:       jsonb("metadata").$type<CreditTransactionMetadata>(),
     createdAt:      timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -62,48 +62,37 @@ export const alreadyAuthGuard: RequestHandler = (req, res, next) => {
     .catch(next);
 };
 
-export const adminDashboardGuard: RequestHandler = (req, res, next) => {
-  auth.api
-    .getSession({ headers: fromNodeHeaders(req.headers) })
-    .then((result) => {
-      if (!result) {
-        res.redirect(302, "/login");
-        return;
-      }
-      const role = toUserRole(result.user.role);
-      if (role !== "admin") {
-        res.status(403).send("Accès refusé");
-        return;
-      }
-      req.user = {
-        id: result.user.id,
-        email: result.user.email,
-        role,
-      };
-      next();
-    })
-    .catch(next);
-};
+export function makeAdminGuard(
+  onUnauth: RequestHandler,
+  onForbidden: RequestHandler,
+): RequestHandler {
+  return (req, res, next) => {
+    auth.api
+      .getSession({ headers: fromNodeHeaders(req.headers) })
+      .then((result) => {
+        if (!result) {
+          onUnauth(req, res, next);
+          return;
+        }
+        const role = toUserRole(result.user.role);
+        if (role !== "admin") {
+          req.user = { id: result.user.id, email: result.user.email, role };
+          onForbidden(req, res, next);
+          return;
+        }
+        req.user = { id: result.user.id, email: result.user.email, role };
+        next();
+      })
+      .catch(next);
+  };
+}
 
-export const requireAdminAuth: RequestHandler = (req, res, next) => {
-  auth.api
-    .getSession({ headers: fromNodeHeaders(req.headers) })
-    .then((result) => {
-      if (!result) {
-        res.status(401).json({ error: "Unauthorized" });
-        return;
-      }
-      const role = toUserRole(result.user.role);
-      if (role !== "admin") {
-        res.status(403).json({ error: "Forbidden" });
-        return;
-      }
-      req.user = {
-        id: result.user.id,
-        email: result.user.email,
-        role,
-      };
-      next();
-    })
-    .catch(next);
-};
+export const adminDashboardGuard = makeAdminGuard(
+  (_req, res) => { res.redirect(302, "/login"); },
+  (_req, res) => { res.status(403).send("Accès refusé"); },
+);
+
+export const requireAdminAuth = makeAdminGuard(
+  (_req, res) => { res.status(401).json({ error: "Unauthorized" }); },
+  (_req, res) => { res.status(403).json({ error: "Forbidden" }); },
+);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -62,6 +62,29 @@ export const alreadyAuthGuard: RequestHandler = (req, res, next) => {
     .catch(next);
 };
 
+export const adminDashboardGuard: RequestHandler = (req, res, next) => {
+  auth.api
+    .getSession({ headers: fromNodeHeaders(req.headers) })
+    .then((result) => {
+      if (!result) {
+        res.redirect(302, "/login");
+        return;
+      }
+      const role = toUserRole(result.user.role);
+      if (role !== "admin") {
+        res.status(403).send("Accès refusé");
+        return;
+      }
+      req.user = {
+        id: result.user.id,
+        email: result.user.email,
+        role,
+      };
+      next();
+    })
+    .catch(next);
+};
+
 export const requireAdminAuth: RequestHandler = (req, res, next) => {
   auth.api
     .getSession({ headers: fromNodeHeaders(req.headers) })

--- a/src/public/admin.html
+++ b/src/public/admin.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scraper — Admin</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg:           #080a0f;
+      --bg-card:      #0d1018;
+      --bg-elevated:  #12151e;
+      --border:       rgba(255,255,255,0.06);
+      --border-hover: rgba(255,255,255,0.11);
+      --text:         #e8e2d9;
+      --muted:        #4e5668;
+      --dim:          #303744;
+      --accent:       #e8622a;
+      --accent-glow:  rgba(232,98,42,0.18);
+      --success:      #22c55e;
+      --warn:         #f59e0b;
+      --danger:       #ef4444;
+      --danger-dim:   rgba(239,68,68,0.12);
+      --mono: 'JetBrains Mono', 'Courier New', monospace;
+    }
+    *, *::before, *::after { margin:0; padding:0; box-sizing:border-box; }
+    body {
+      font-family: var(--mono);
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      padding: 2rem;
+      font-size: 0.85rem;
+    }
+    ::-webkit-scrollbar { width: 4px; height: 4px; }
+    ::-webkit-scrollbar-thumb { background: var(--dim); border-radius: 4px; }
+
+    header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 2rem; }
+    h1 { font-size: 1.1rem; font-weight: 600; letter-spacing: 0.02em; }
+    h1 span { color: var(--accent); }
+    .back-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.8rem;
+      border: 1px solid var(--border);
+      padding: 0.5rem 0.9rem;
+      border-radius: 4px;
+    }
+    .back-link:hover { color: var(--text); border-color: var(--border-hover); }
+
+    .toolbar { display: flex; gap: 0.75rem; margin-bottom: 1rem; }
+    input[type="text"], input[type="number"], textarea {
+      font-family: var(--mono);
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      padding: 0.6rem 0.8rem;
+      font-size: 0.82rem;
+      outline: none;
+    }
+    input[type="text"]:focus, input[type="number"]:focus, textarea:focus { border-color: var(--accent); }
+    #searchInput { flex: 1; }
+
+    table { width: 100%; border-collapse: collapse; background: var(--bg-card); border: 1px solid var(--border); border-radius: 4px; }
+    th, td { padding: 0.6rem 0.85rem; text-align: left; border-bottom: 1px solid var(--border); font-size: 0.8rem; }
+    th { color: var(--muted); font-weight: 500; background: var(--bg-elevated); }
+    tbody tr { cursor: pointer; }
+    tbody tr:hover { background: var(--bg-elevated); }
+    .role-admin { color: var(--accent); font-weight: 500; }
+    .amount-pos { color: var(--success); }
+    .amount-neg { color: var(--danger); }
+    .muted { color: var(--muted); }
+
+    .modal-backdrop {
+      position: fixed; inset: 0;
+      background: rgba(0,0,0,0.7);
+      display: none;
+      align-items: flex-start;
+      justify-content: center;
+      padding: 3rem 2rem;
+      overflow-y: auto;
+      z-index: 10;
+    }
+    .modal-backdrop.open { display: flex; }
+    .modal {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      width: 100%;
+      max-width: 720px;
+      padding: 1.5rem;
+    }
+    .modal-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+    .modal-close { background: none; border: none; color: var(--muted); cursor: pointer; font-family: var(--mono); font-size: 1.2rem; }
+    .modal-close:hover { color: var(--text); }
+    .stats-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; margin-bottom: 1.25rem; }
+    .stat-card { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 4px; padding: 0.75rem; }
+    .stat-label { color: var(--muted); font-size: 0.7rem; margin-bottom: 0.3rem; }
+    .stat-value { font-size: 0.95rem; font-weight: 500; }
+
+    .section-title { color: var(--muted); font-size: 0.75rem; margin: 1.25rem 0 0.6rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    form.credit-form { display: grid; grid-template-columns: 1fr 2fr auto; gap: 0.6rem; }
+    form.credit-form textarea { grid-column: span 2; resize: vertical; min-height: 2.4rem; }
+    button.btn {
+      font-family: var(--mono);
+      background: var(--accent);
+      border: none;
+      color: #0a0c12;
+      padding: 0.6rem 1rem;
+      font-size: 0.8rem;
+      font-weight: 500;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    button.btn:hover { filter: brightness(1.08); }
+    button.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .toast {
+      position: fixed; bottom: 2rem; right: 2rem;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border-hover);
+      padding: 0.8rem 1.2rem;
+      border-radius: 4px;
+      font-size: 0.82rem;
+      opacity: 0;
+      transform: translateY(10px);
+      transition: all 0.2s;
+      z-index: 20;
+    }
+    .toast.show { opacity: 1; transform: translateY(0); }
+    .toast.error { border-color: var(--danger); color: var(--danger); }
+    .toast.success { border-color: var(--success); color: var(--success); }
+
+    .tx-table td { font-size: 0.76rem; }
+    .tx-note { color: var(--muted); font-style: italic; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Scraper <span>/ Admin</span></h1>
+    <a class="back-link" href="/">← Retour au dashboard</a>
+  </header>
+
+  <div class="toolbar">
+    <input id="searchInput" type="text" placeholder="Rechercher par email…" autocomplete="off">
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Email</th>
+        <th>Rôle</th>
+        <th>Balance</th>
+        <th>Total achats</th>
+        <th>Total scrapé</th>
+        <th>Créé le</th>
+      </tr>
+    </thead>
+    <tbody id="usersBody">
+      <tr><td colspan="6" class="muted">Chargement…</td></tr>
+    </tbody>
+  </table>
+
+  <div class="modal-backdrop" id="modal">
+    <div class="modal">
+      <div class="modal-header">
+        <div>
+          <div class="muted" style="font-size:0.72rem;">USER</div>
+          <div id="modalEmail" style="font-size:0.95rem; font-weight:500;"></div>
+        </div>
+        <button class="modal-close" onclick="closeModal()">×</button>
+      </div>
+
+      <div class="stats-grid">
+        <div class="stat-card"><div class="stat-label">Balance</div><div class="stat-value" id="modalBalance">—</div></div>
+        <div class="stat-card"><div class="stat-label">Total achats</div><div class="stat-value" id="modalPurchases">—</div></div>
+        <div class="stat-card"><div class="stat-label">Total scrapé</div><div class="stat-value" id="modalScraped">—</div></div>
+        <div class="stat-card"><div class="stat-label">Rôle</div><div class="stat-value" id="modalRole">—</div></div>
+      </div>
+
+      <div class="section-title">Ajuster les crédits</div>
+      <form class="credit-form" id="creditForm">
+        <input type="number" id="creditAmount" placeholder="±N crédits" required>
+        <textarea id="creditNote" placeholder="Note (raison de l'ajustement)" required maxlength="500"></textarea>
+        <button type="submit" class="btn">Appliquer</button>
+      </form>
+
+      <div class="section-title">50 dernières transactions</div>
+      <table class="tx-table">
+        <thead><tr><th>Date</th><th>Type</th><th>Amount</th><th>Note</th></tr></thead>
+        <tbody id="txBody"><tr><td colspan="4" class="muted">—</td></tr></tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="toast" id="toast"></div>
+
+  <script>
+    const state = { currentUserId: null, searchTimer: null };
+
+    async function bootstrap() {
+      const meRes = await fetch("/api/me");
+      if (!meRes.ok) { window.location.href = "/login"; return; }
+      const me = await meRes.json();
+      if (!me || !me.user || me.user.role !== "admin") {
+        window.location.href = "/";
+        return;
+      }
+      loadUsers();
+    }
+
+    async function loadUsers(search = "") {
+      const qs = search ? `?search=${encodeURIComponent(search)}` : "";
+      const res = await fetch(`/api/admin/users${qs}`);
+      if (!res.ok) { toast("Erreur de chargement", "error"); return; }
+      const { users } = await res.json();
+      renderUsers(users);
+    }
+
+    function renderUsers(users) {
+      const body = document.getElementById("usersBody");
+      if (!users.length) { body.innerHTML = `<tr><td colspan="6" class="muted">Aucun user</td></tr>`; return; }
+      body.innerHTML = users.map((u) => `
+        <tr onclick="openModal('${u.id}')">
+          <td>${escapeHtml(u.email)}</td>
+          <td class="${u.role === "admin" ? "role-admin" : ""}">${escapeHtml(u.role)}</td>
+          <td>${u.balance}</td>
+          <td>${u.totalPurchases}</td>
+          <td>${u.totalScraped}</td>
+          <td class="muted">${formatDate(u.createdAt)}</td>
+        </tr>
+      `).join("");
+    }
+
+    async function openModal(userId) {
+      state.currentUserId = userId;
+      document.getElementById("modal").classList.add("open");
+      await refreshModal();
+    }
+
+    async function refreshModal() {
+      const res = await fetch(`/api/admin/users/${state.currentUserId}`);
+      if (!res.ok) { toast("User introuvable", "error"); closeModal(); return; }
+      const d = await res.json();
+      document.getElementById("modalEmail").textContent = d.email;
+      document.getElementById("modalBalance").textContent = d.balance;
+      document.getElementById("modalPurchases").textContent = d.totalPurchases;
+      document.getElementById("modalScraped").textContent = d.totalScraped;
+      document.getElementById("modalRole").textContent = d.role;
+      renderTransactions(d.transactions);
+    }
+
+    function renderTransactions(txs) {
+      const body = document.getElementById("txBody");
+      if (!txs.length) { body.innerHTML = `<tr><td colspan="4" class="muted">Aucune transaction</td></tr>`; return; }
+      body.innerHTML = txs.map((t) => `
+        <tr>
+          <td class="muted">${formatDate(t.createdAt)}</td>
+          <td>${escapeHtml(t.type)}</td>
+          <td class="${t.amount >= 0 ? "amount-pos" : "amount-neg"}">${t.amount >= 0 ? "+" : ""}${t.amount}</td>
+          <td class="tx-note">${t.metadata && t.metadata.note ? escapeHtml(t.metadata.note) : "—"}</td>
+        </tr>
+      `).join("");
+    }
+
+    function closeModal() {
+      document.getElementById("modal").classList.remove("open");
+      state.currentUserId = null;
+      document.getElementById("creditForm").reset();
+    }
+
+    document.getElementById("creditForm").addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const amount = Number(document.getElementById("creditAmount").value);
+      const note = document.getElementById("creditNote").value.trim();
+      if (!amount || !note) return;
+      const btn = e.target.querySelector("button");
+      btn.disabled = true;
+      try {
+        const res = await fetch(`/api/admin/users/${state.currentUserId}/credits`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ amount, note }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          toast(data.error || "Erreur", "error");
+          return;
+        }
+        toast(`Balance : ${data.balance}`, "success");
+        document.getElementById("creditForm").reset();
+        await refreshModal();
+        await loadUsers(document.getElementById("searchInput").value.trim());
+      } finally {
+        btn.disabled = false;
+      }
+    });
+
+    document.getElementById("searchInput").addEventListener("input", (e) => {
+      clearTimeout(state.searchTimer);
+      state.searchTimer = setTimeout(() => loadUsers(e.target.value.trim()), 200);
+    });
+
+    document.getElementById("modal").addEventListener("click", (e) => {
+      if (e.target.id === "modal") closeModal();
+    });
+
+    function formatDate(iso) {
+      const d = new Date(iso);
+      return d.toLocaleDateString("fr-FR") + " " + d.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+    }
+
+    function escapeHtml(s) {
+      if (s == null) return "";
+      return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+    }
+
+    function toast(msg, kind = "") {
+      const el = document.getElementById("toast");
+      el.textContent = msg;
+      el.className = `toast show ${kind}`;
+      setTimeout(() => el.classList.remove("show"), 2500);
+    }
+
+    bootstrap();
+  </script>
+</body>
+</html>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -796,6 +796,7 @@
         <button class="nav-tab active" id="navResults"  onclick="setView('results')">Résultats</button>
         <button class="nav-tab"        id="navFilters"  onclick="setView('filters')">Filtres</button>
         <button class="nav-tab"        id="navDuplicates" onclick="setView('duplicates')">Doublons</button>
+        <button class="nav-tab"        id="navAdmin" style="display:none" onclick="window.location.href='/admin'">Admin</button>
       </div>
     </div>
 
@@ -1792,6 +1793,17 @@ function setExportScope(scope) {
       toast(labels[exportScope] || "Téléchargement du CSV…");
     }
 
+    async function revealAdminLink() {
+      try {
+        const r = await fetch("/api/me");
+        if (!r.ok) return;
+        const me = await r.json();
+        if (me && me.user && me.user.role === "admin") {
+          document.getElementById("navAdmin").style.display = "";
+        }
+      } catch (_) { /* silencieux */ }
+    }
+
     /* ── Init ── */
     fetchStats();
     fetchResults();
@@ -1800,6 +1812,7 @@ function setExportScope(scope) {
     fetchFilterOptions();
     refreshCredits();
     pollStatus();
+    revealAdminLink();
 
     /* Auto-refresh résultats toutes les 10s si idle */
     setInterval(function() {

--- a/src/schemas/admin.schema.ts
+++ b/src/schemas/admin.schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const adminCreditBodySchema = z
+  .object({
+    amount: z
+      .number()
+      .int()
+      .refine((n) => n !== 0, { message: "amount ne peut pas être 0" }),
+    note: z.string().trim().min(1).max(500),
+  })
+  .strict();
+
+export const adminUsersQuerySchema = z
+  .object({
+    search: z.string().trim().min(1).optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+    offset: z.coerce.number().int().min(0).default(0),
+  })
+  .strict();
+
+export type AdminCreditBody = z.infer<typeof adminCreditBodySchema>;
+export type AdminUsersQuery = z.infer<typeof adminUsersQuerySchema>;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -8,3 +8,9 @@ export {
   type ExportQuery,
 } from "./filters.schema.js";
 export { polarWebhookSchema, type PolarWebhook } from "./billing.schema.js";
+export {
+  adminCreditBodySchema,
+  adminUsersQuerySchema,
+  type AdminCreditBody,
+  type AdminUsersQuery,
+} from "./admin.schema.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,10 +8,11 @@ import { runMigrations } from "./db/migrate.js";
 import { seedProfessions } from "./db/seeds/professions.js";
 import { toNodeHandler, fromNodeHeaders } from "better-auth/node";
 import { auth } from "./auth.js";
-import { requireAuth, dashboardGuard, alreadyAuthGuard } from "./middleware/auth.js";
+import { requireAuth, dashboardGuard, alreadyAuthGuard, adminDashboardGuard, requireAdminAuth } from "./middleware/auth.js";
 import { validateBody, validateQuery, getValidatedQuery } from "./middleware/validate.js";
 import { getStats, streamAll, getPaginated, getFilterOptions, getPhoneDuplicates, cleanPhoneDuplicates, getNameDuplicates, cleanNameDuplicates, getExcludedCount, ResultFilters } from "./db/scraped.js";
-import { getBalance, getRecentTransactions } from "./db/credits.js";
+import { getBalance, getRecentTransactions, adminGrant, InsufficientCreditsError } from "./db/credits.js";
+import { listUsers, getUserDetail } from "./db/admin.js";
 import { listActiveProfessions, getProfessionById } from "./db/professions.js";
 import { sql } from "drizzle-orm";
 import { db, closeDb } from "./db/client.js";
@@ -21,9 +22,13 @@ import {
   scrapeBodySchema,
   resultsQuerySchema,
   exportQuerySchema,
+  adminCreditBodySchema,
+  adminUsersQuerySchema,
   type ScrapeBody,
   type ResultsQuery,
   type ExportQuery,
+  type AdminCreditBody,
+  type AdminUsersQuery,
 } from "./schemas/index.js";
 
 const asyncHandler =
@@ -83,6 +88,13 @@ app.get("/signup", alreadyAuthGuard, (_req, res) => {
   res.sendFile(path.join(__dirname, "views", "signup.html"));
 });
 
+app.get("/admin", adminDashboardGuard, (_req, res) => {
+  res.sendFile(path.join(__dirname, "public", "admin.html"));
+});
+app.get("/admin.html", adminDashboardGuard, (_req, res) => {
+  res.sendFile(path.join(__dirname, "public", "admin.html"));
+});
+
 app.use(express.static(path.join(__dirname, "public")));
 
 app.get("/api/me", requireAuth, asyncHandler(async (req, res) => {
@@ -105,6 +117,67 @@ app.get("/api/credits", requireAuth, asyncHandler(async (req, res) => {
       createdAt: t.createdAt.toISOString(),
     })),
   });
+}));
+
+app.get("/api/admin/users", requireAdminAuth, validateQuery(adminUsersQuerySchema), asyncHandler(async (_req, res) => {
+  const query = getValidatedQuery<AdminUsersQuery>(res);
+  const users = await listUsers(query);
+  res.json({
+    users: users.map((u) => ({
+      id: u.id,
+      email: u.email,
+      createdAt: u.createdAt.toISOString(),
+      role: u.role,
+      balance: u.balance,
+      totalPurchases: u.totalPurchases,
+      totalScraped: u.totalScraped,
+    })),
+  });
+}));
+
+app.get("/api/admin/users/:userId", requireAdminAuth, asyncHandler(async (req, res) => {
+  const detail = await getUserDetail(req.params.userId);
+  if (!detail) {
+    res.status(404).json({ error: "User introuvable" });
+    return;
+  }
+  res.json({
+    id: detail.id,
+    email: detail.email,
+    createdAt: detail.createdAt.toISOString(),
+    role: detail.role,
+    balance: detail.balance,
+    totalPurchases: detail.totalPurchases,
+    totalScraped: detail.totalScraped,
+    transactions: detail.transactions.map((t) => ({
+      id: t.id,
+      type: t.type,
+      amount: t.amount,
+      metadata: t.metadata,
+      createdAt: t.createdAt.toISOString(),
+    })),
+  });
+}));
+
+app.post("/api/admin/users/:userId/credits", requireAdminAuth, validateBody(adminCreditBodySchema), asyncHandler(async (req, res) => {
+  const { amount, note } = req.body as AdminCreditBody;
+  const targetUserId = req.params.userId;
+  const detail = await getUserDetail(targetUserId);
+  if (!detail) {
+    res.status(404).json({ error: "User introuvable" });
+    return;
+  }
+  try {
+    await adminGrant(targetUserId, amount, { adminId: req.user!.id, note });
+  } catch (err) {
+    if (err instanceof InsufficientCreditsError) {
+      res.status(409).json({ error: "Solde insuffisant pour ce débit" });
+      return;
+    }
+    throw err;
+  }
+  const balance = await getBalance(targetUserId);
+  res.json({ balance });
 }));
 
 function pickFilters(query: ResultsQuery | ExportQuery): ResultFilters {

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,10 +89,7 @@ app.get("/signup", alreadyAuthGuard, (_req, res) => {
 });
 
 app.get("/admin", adminDashboardGuard, (_req, res) => {
-  res.sendFile(path.join(__dirname, "public", "admin.html"));
-});
-app.get("/admin.html", adminDashboardGuard, (_req, res) => {
-  res.sendFile(path.join(__dirname, "public", "admin.html"));
+  res.sendFile(path.join(__dirname, "views", "admin.html"));
 });
 
 app.use(express.static(path.join(__dirname, "public")));
@@ -162,16 +159,15 @@ app.get("/api/admin/users/:userId", requireAdminAuth, asyncHandler(async (req, r
 app.post("/api/admin/users/:userId/credits", requireAdminAuth, validateBody(adminCreditBodySchema), asyncHandler(async (req, res) => {
   const { amount, note } = req.body as AdminCreditBody;
   const targetUserId = req.params.userId;
-  const detail = await getUserDetail(targetUserId);
-  if (!detail) {
-    res.status(404).json({ error: "User introuvable" });
-    return;
-  }
   try {
     await adminGrant(targetUserId, amount, { adminId: req.user!.id, note });
   } catch (err) {
     if (err instanceof InsufficientCreditsError) {
-      res.status(409).json({ error: "Solde insuffisant pour ce débit" });
+      res.status(409).json({ error: "Débit impossible : solde insuffisant ou user sans crédits" });
+      return;
+    }
+    if (typeof err === "object" && err !== null && "code" in err && (err as { code?: string }).code === "23503") {
+      res.status(404).json({ error: "User introuvable" });
       return;
     }
     throw err;

--- a/src/views/admin.html
+++ b/src/views/admin.html
@@ -201,17 +201,6 @@
   <script>
     const state = { currentUserId: null, searchTimer: null };
 
-    async function bootstrap() {
-      const meRes = await fetch("/api/me");
-      if (!meRes.ok) { window.location.href = "/login"; return; }
-      const me = await meRes.json();
-      if (!me || !me.user || me.user.role !== "admin") {
-        window.location.href = "/";
-        return;
-      }
-      loadUsers();
-    }
-
     async function loadUsers(search = "") {
       const qs = search ? `?search=${encodeURIComponent(search)}` : "";
       const res = await fetch(`/api/admin/users${qs}`);
@@ -224,7 +213,7 @@
       const body = document.getElementById("usersBody");
       if (!users.length) { body.innerHTML = `<tr><td colspan="6" class="muted">Aucun user</td></tr>`; return; }
       body.innerHTML = users.map((u) => `
-        <tr onclick="openModal('${u.id}')">
+        <tr data-user-id="${escapeHtml(u.id)}">
           <td>${escapeHtml(u.email)}</td>
           <td class="${u.role === "admin" ? "role-admin" : ""}">${escapeHtml(u.role)}</td>
           <td>${u.balance}</td>
@@ -234,6 +223,12 @@
         </tr>
       `).join("");
     }
+
+    document.getElementById("usersBody").addEventListener("click", (e) => {
+      const tr = e.target.closest("tr");
+      const userId = tr && tr.dataset.userId;
+      if (userId) openModal(userId);
+    });
 
     async function openModal(userId) {
       state.currentUserId = userId;
@@ -325,7 +320,7 @@
       setTimeout(() => el.classList.remove("show"), 2500);
     }
 
-    bootstrap();
+    loadUsers();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Contexte

Panel d'administration permettant à l'admin de consulter les users, leurs statistiques et d'ajuster manuellement leurs crédits (geste commercial, refund, support).

Closes #51

## Ce qui a été implémenté

### Routes API (protégées par `requireAdminAuth`)
- `GET /api/admin/users` — liste paginée avec `search`, `limit` (max 100), `offset` ; chaque user expose balance, total achats en crédits et total fiches scrapées
- `GET /api/admin/users/:userId` — détail user + 50 dernières transactions
- `POST /api/admin/users/:userId/credits` — body `{ amount, note }` : ajustement positif (crédit) ou négatif (débit) ; `409` si solde insuffisant

### Page `/admin`
- Servie depuis `src/views/` (hors `express.static`) via `adminDashboardGuard`
- Liste users avec recherche debounced par email
- Modal : stats + tableau des 50 dernières transactions + formulaire crédit/débit avec note
- Lien "Admin" conditionnel dans la navbar (`index.html`) visible uniquement si `role === "admin"`

### Couche DB & schémas
- Migration `0007` : colonne `metadata jsonb NULL` sur `credit_transactions` (trace `admin_id` + `note`)
- `src/db/admin.ts` : `listUsers` et `getUserDetail` avec agrégats via sous-requêtes corrélées
- `src/schemas/admin.schema.ts` : `adminCreditBodySchema` + `adminUsersQuerySchema` (Zod)

### Sécurité & refactors (review)
- XSS corrigé : ids utilisateurs dans `data-user-id` au lieu d'attributs `onclick` inline
- `makeAdminGuard(onUnauth, onForbidden)` factorisé pour mutualiser `requireAdminAuth` et `adminDashboardGuard`
- Pré-check `getUserDetail` supprimé dans le handler POST ; FK violation capturée en 404

## Checklist

- [x] `/admin` retourne 403 pour un user normal
- [x] `GET /api/admin/users` liste paginée avec stats
- [x] `POST /api/admin/users/:userId/credits` crédite/débite avec note tracée dans `credit_transactions`
- [x] Toute action admin tracée (`type='admin_grant'`, `metadata.admin_id`, `metadata.note`)
- [x] Lien `/admin` affiché dans la navbar uniquement pour les admins
- [x] Migration DB générée et versionée